### PR TITLE
Add function name, order by line number and add request/response headers

### DIFF
--- a/lib/bureaucrat/formatter.ex
+++ b/lib/bureaucrat/formatter.ex
@@ -17,8 +17,12 @@ defmodule Bureaucrat.Formatter do
 
   defp generate_docs do
     records = Bureaucrat.Recorder.get_records
-    writer = Application.get_env(:bureaucrat, :writer)
-    grouped = group_by_path(records)
+    writer  = Application.get_env(:bureaucrat, :writer)
+    grouped =
+      records
+      |> Enum.sort_by(&(-1 * &1.assigns.bureaucrat_line))
+      |> group_by_path
+
     Enum.map(grouped, fn {path, recs} ->
       apply(writer, :write, [recs, path])
     end)

--- a/lib/bureaucrat/helpers.ex
+++ b/lib/bureaucrat/helpers.ex
@@ -1,6 +1,13 @@
 defmodule Bureaucrat.Helpers do
-  def doc(conn, desc \\ nil) do
-    Bureaucrat.Recorder.doc(conn, desc)
-    conn
+  defmacro doc(conn, desc \\ nil) do
+    fun  = __CALLER__.function |> elem(0) |> to_string
+    line = __CALLER__.line
+
+    quote bind_quoted: [desc: desc, conn: conn, fun: fun, line: line] do
+      Bureaucrat.Recorder.doc(conn, desc || format_test_name(fun), line)
+      conn
+    end
   end
+
+  def format_test_name("test " <> name), do: name
 end

--- a/lib/bureaucrat/markdown_writer.ex
+++ b/lib/bureaucrat/markdown_writer.ex
@@ -40,6 +40,7 @@ defmodule Bureaucrat.MarkdownWriter do
     end
 
     file
+    |> puts("### #{record.assigns.bureaucrat_desc}")
     |> puts("* __Method:__ #{record.method}")
     |> puts("* __Path:__ #{path}")
 
@@ -59,6 +60,7 @@ defmodule Bureaucrat.MarkdownWriter do
     |> puts("```json")
     |> puts("#{format_resp_body(record.resp_body)}")
     |> puts("```")
+    |> puts("")
   end
 
   def format_body_params(params) do

--- a/lib/bureaucrat/markdown_writer.ex
+++ b/lib/bureaucrat/markdown_writer.ex
@@ -41,10 +41,22 @@ defmodule Bureaucrat.MarkdownWriter do
 
     file
     |> puts("### #{record.assigns.bureaucrat_desc}")
+    |> puts("#### Request")
     |> puts("* __Method:__ #{record.method}")
     |> puts("* __Path:__ #{path}")
 
-    # TODO maybe show req_headers
+    unless record.req_headers == [] do
+      file
+      |> puts("* __Request headers:__")
+      |> puts("```")
+
+      Enum.each record.req_headers, fn({header, value}) ->
+        puts file, "#{header}: #{value}"
+      end
+
+      file
+      |> puts("```")
+    end
 
     unless record.body_params == %{} do
       file
@@ -55,7 +67,24 @@ defmodule Bureaucrat.MarkdownWriter do
     end
 
     file
+    |> puts("#### Response")
     |> puts("* __Status__: #{record.status}")
+
+
+    unless record.resp_headers == [] do
+      file
+      |> puts("* __Response headers:__")
+      |> puts("```")
+
+      Enum.each record.resp_headers, fn({header, value}) ->
+        puts file, "#{header}: #{value}"
+      end
+
+      file
+      |> puts("```")
+    end
+
+    file
     |> puts("* __Response body:__")
     |> puts("```json")
     |> puts("#{format_resp_body(record.resp_body)}")

--- a/lib/bureaucrat/markdown_writer.ex
+++ b/lib/bureaucrat/markdown_writer.ex
@@ -40,8 +40,8 @@ defmodule Bureaucrat.MarkdownWriter do
     end
 
     file
-    |> puts("### #{record.assigns.bureaucrat_desc}")
-    |> puts("#### Request")
+    |> puts("#### #{record.assigns.bureaucrat_desc}")
+    |> puts("##### Request")
     |> puts("* __Method:__ #{record.method}")
     |> puts("* __Path:__ #{path}")
 
@@ -67,7 +67,7 @@ defmodule Bureaucrat.MarkdownWriter do
     end
 
     file
-    |> puts("#### Response")
+    |> puts("##### Response")
     |> puts("* __Status__: #{record.status}")
 
 

--- a/lib/bureaucrat/recorder.ex
+++ b/lib/bureaucrat/recorder.ex
@@ -5,8 +5,8 @@ defmodule Bureaucrat.Recorder do
     {:ok, _} = GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
 
-  def doc(conn, desc) do
-    GenServer.cast(__MODULE__, {:doc, conn, desc})
+  def doc(conn, desc, line) do
+    GenServer.cast(__MODULE__, {:doc, conn, desc, line})
   end
 
   def get_records do
@@ -17,8 +17,11 @@ defmodule Bureaucrat.Recorder do
     {:ok, []}
   end
 
-  def handle_cast({:doc, conn, desc}, records) do
-    conn = Plug.Conn.assign(conn, :bureaucrat_desc, desc)
+  def handle_cast({:doc, conn, desc, line}, records) do
+    conn =
+      conn
+      |> Plug.Conn.assign(:bureaucrat_desc, desc)
+      |> Plug.Conn.assign(:bureaucrat_line, line)
     {:noreply, [conn | records]}
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,2 @@
 %{"plug": {:hex, :plug, "1.0.0"},
-  "poison": {:git, "git://github.com/devinus/poison.git", "53de16a8dcb67d896d1d2b8ea91b9d506b8d83f4", [branch: "master"]}}
+  "poison": {:git, "https://github.com/devinus/poison.git", "53de16a8dcb67d896d1d2b8ea91b9d506b8d83f4", [branch: "master"]}}


### PR DESCRIPTION
Really love this tool!

I noticed that you can add a `desc` to `doc` but it wouldn't show up anywhere. I also wanted it to default to the test name. For that I turned `doc` into a macro.

That also allows us to generate the documentation in the same order as the tests are in the file. The one and only time we should order tests. :)

Lastly I added request and response headers and devided the payload up into two chunks.

This is all up for discussion, thanks for doing this!

Cheers