### PR TITLE
add linebreak to header for compat with ex_doc

### DIFF
--- a/lib/bureaucrat/markdown_writer.ex
+++ b/lib/bureaucrat/markdown_writer.ex
@@ -2,7 +2,7 @@ defmodule Bureaucrat.MarkdownWriter do
   def write(records, path) do
     {:ok, file} = File.open path, [:write, :utf8]
     records = group_records(records)
-    puts(file, "# API Documentation")
+    puts(file, "# API Documentation\n")
     write_table_of_contents(records, file)
     Enum.each(records, fn {controller, records} ->
       write_controller(controller, records, file)


### PR DESCRIPTION
## Problem:

`ex_doc` expects a linebreak after header to use the header text as the page title in documentation sidebar.

![mothra 2016-03-29 14-03-08](https://cloud.githubusercontent.com/assets/81008/14118318/fd96bad6-f5b6-11e5-8277-991191b88986.png)

#### Before:
![readme mothra api v0 0 1 2016-03-29 14-05-10](https://cloud.githubusercontent.com/assets/81008/14118398/4c4195de-f5b7-11e5-93c1-05669f5eb185.png)

## Solution:

Add a single linebreak after header. :smiley_cat: 

#### After:
![api documentation mothra api v0 0 1 2016-03-29 14-03-54](https://cloud.githubusercontent.com/assets/81008/14118354/20106a8a-f5b7-11e5-9e4a-db05e7d539d6.png)
