### PR TITLE
Markdown writer including swagger info

### DIFF
--- a/lib/bureaucrat/swagger_slate_markdown_writer.ex
+++ b/lib/bureaucrat/swagger_slate_markdown_writer.ex
@@ -67,7 +67,8 @@ eg by passing it as an option to the Bureaucrat.start/1 function.
     |> puts("# Authentication\n")
 
     # TODO: Document token based security
-    Enum.each swagger["security"], fn {name, _details} ->
+    Enum.each swagger["security"], fn securityRequirement ->
+       name = Map.keys(securityRequirement) |> List.first
        definition = swagger["securityDefinitions"][name]
        file
        |> puts("## #{definition["type"]}\n")

--- a/lib/bureaucrat/swagger_slate_markdown_writer.ex
+++ b/lib/bureaucrat/swagger_slate_markdown_writer.ex
@@ -119,7 +119,7 @@ eg by passing it as an option to the Bureaucrat.start/1 function.
   """
   def write_model_properties(file, model_schema, prefix \\ "") do
     Enum.each model_schema["properties"], fn {property, property_details} ->
-      required? = property in model_schema["required"]
+      required? = is_required(property, model_schema)
       type = property_details["type"]
       write_model_property(file, "#{prefix}#{property}", property_details, type, required?)
     end
@@ -141,6 +141,9 @@ eg by passing it as an option to the Bureaucrat.start/1 function.
   def write_model_property(file, property, property_details, type, required?) do
     puts(file, "|#{property}|#{property_details["description"]}|#{type}|#{required?}|")
   end
+
+  defp is_required(property, %{"required" => required}), do: property in required
+  defp is_required(_property, _schema), do: false
 
   # Convert a schema reference eg, #/definitions/User to a markdown link
   defp schema_ref_to_link(schema_ref) do


### PR DESCRIPTION
This PR contains a markdown writer module that merges data from a swagger spec, and outputs in a format that can be used with the [slate static site generator](https://github.com/tripit/slate).

Related Issues: #8, #9

I've only implemented enough to get our internal API docs generating successfully, but hopefully this is enough to get started.

[Example swagger file](https://gist.github.com/mbuhot/bdc13d96accea92d68514ea2193d1f42)
[Example generated output](https://gist.github.com/mbuhot/ae1c182c4de4897e910bd6b1e942e626)


Document structure is:

Overview
 - From the swagger info section

Authentication
 - From the swagger securityDefinitions section

Models
 - From the swagger definitions section
 - Nested models are flattened into a single table

Operations
 - From the swagger paths section
 - Groups first by tag, to match the behaviour of swagger-ui
 - Then by the bureaucrat test description
 - Requires that each swagger operationId is set to the qualified phoenix controller action,
   eg, "operationId" : "MyApp.UserController.index"

Usage:

```
Bureaucrat.start(
  writer: Bureaucrat.SwaggerSlateMarkdownWriter,
  default_path: "index.md",
  paths: [],
  env_var: "DOC",
  swagger: (File.read("swagger.json") |> elem(1) |> Poison.decode!))
```