### PR TITLE
Keyword options for doc macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Usage
 -----
 
 Bureaucrat collects data from connection structs used in tests.
-If you want a connection to be documented, pass it to the `doc/1` funciton:
+If you want a connection to be documented, pass it to the `doc/1` function:
 
 ```elixir
 test "GET /api/v1/products" do
@@ -56,6 +56,18 @@ test "GET /api/v1/products" do
       |> doc
   assert conn.status == 200
 end
+```
+
+Additional options can be passed to the backend formatter:
+
+```elixir
+test "GET /api/v1/products" do
+  conn = conn()
+      |> get("/api/v1/products")
+      |> doc(description: "List all products", operation_id: "list_products")
+  assert conn.status == 200
+end
+
 ```
 
 Then, to generate the documentation file(s) run `DOC=1 mix test`.

--- a/lib/bureaucrat/helpers.ex
+++ b/lib/bureaucrat/helpers.ex
@@ -1,10 +1,48 @@
 defmodule Bureaucrat.Helpers do
-  defmacro doc(conn, desc \\ nil) do
+
+  @doc """
+  Adds a conn to the generated documentation.
+
+  The name of the test currently being executed will be used as a description for the example.
+  """
+  defmacro doc(conn) do
+    quote bind_quoted: [conn: conn] do
+      doc(conn, [])
+    end
+  end
+
+  @doc """
+  Adds a conn to the generated documentation
+
+  The description, and additional options can be passed in the second argument:
+
+  ## Examples
+
+      conn = conn()
+        |> get("/api/v1/products")
+        |> doc("List all products")
+
+      conn = conn()
+        |> get("/api/v1/products")
+        |> doc(description: "List all products", operation_id: "list_products")
+  """
+  defmacro doc(conn, desc) when is_binary(desc)  do
+    quote bind_quoted: [conn: conn, desc: desc] do
+      doc(conn, description: desc)
+    end
+  end
+
+  defmacro doc(conn, opts) when is_list(opts) do
     fun  = __CALLER__.function |> elem(0) |> to_string
     line = __CALLER__.line
 
-    quote bind_quoted: [desc: desc, conn: conn, fun: fun, line: line] do
-      Bureaucrat.Recorder.doc(conn, desc || format_test_name(fun), line)
+    opts =
+      opts
+      |> Keyword.put_new(:description, format_test_name(fun))
+      |> Keyword.put(:line, line)
+
+    quote bind_quoted: [conn: conn, opts: opts] do
+      Bureaucrat.Recorder.doc(conn, opts)
       conn
     end
   end

--- a/lib/bureaucrat/recorder.ex
+++ b/lib/bureaucrat/recorder.ex
@@ -5,8 +5,8 @@ defmodule Bureaucrat.Recorder do
     {:ok, _} = GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
 
-  def doc(conn, desc, line) do
-    GenServer.cast(__MODULE__, {:doc, conn, desc, line})
+  def doc(conn, opts) do
+    GenServer.cast(__MODULE__, {:doc, conn, opts})
   end
 
   def get_records do
@@ -17,11 +17,13 @@ defmodule Bureaucrat.Recorder do
     {:ok, []}
   end
 
-  def handle_cast({:doc, conn, desc, line}, records) do
+  def handle_cast({:doc, conn, opts}, records) do
     conn =
       conn
-      |> Plug.Conn.assign(:bureaucrat_desc, desc)
-      |> Plug.Conn.assign(:bureaucrat_line, line)
+      |> Plug.Conn.assign(:bureaucrat_desc, opts[:description])
+      |> Plug.Conn.assign(:bureaucrat_line, opts[:line])
+      |> Plug.Conn.assign(:bureaucrat_opts, opts)
+
     {:noreply, [conn | records]}
   end
 

--- a/lib/bureaucrat/swagger_slate_markdown_writer.ex
+++ b/lib/bureaucrat/swagger_slate_markdown_writer.ex
@@ -195,16 +195,8 @@ eg by passing it as an option to the Bureaucrat.start/1 function.
   Tag a single record with swagger tag and operation_id.
   """
   def tag_record(conn, tags_by_operation_id) do
-    controller =
-      conn.private.phoenix_controller
-      |> to_string()
-      |> String.replace_prefix("Elixir.","")
-
-    action = conn.private.phoenix_action
-    operation_id = "#{controller}.#{action}"
-    conn
-    |> Conn.put_private(:swagger_tag, tags_by_operation_id[operation_id])
-    |> Conn.put_private(:swagger_operation_id, operation_id)
+    operation_id = conn.assigns.bureaucrat_opts[:operation_id]
+    Conn.put_private(conn, :swagger_tag, tags_by_operation_id[operation_id])
   end
 
   @doc """
@@ -213,7 +205,7 @@ eg by passing it as an option to the Bureaucrat.start/1 function.
   def group_records(records) do
     by_tag = Enum.group_by(records, &(&1.private.swagger_tag))
     Enum.map by_tag, fn {tag, records_with_tag} ->
-      by_operation_id = Enum.group_by(records_with_tag, &(&1.private.swagger_operation_id))
+      by_operation_id = Enum.group_by(records_with_tag, &(&1.assigns.bureaucrat_opts[:operation_id]))
       {tag, by_operation_id}
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -26,8 +26,8 @@ defmodule Bureaucrat.Mixfile do
 
   defp deps do
     [
-     {:plug, "~> 0.14 or ~> 1.0"},
-     {:poison, github: "devinus/poison", branch: "master"}
+     {:plug, "~> 1.0"},
+     {:poison, "~> 3.0"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,2 @@
-%{"plug": {:hex, :plug, "1.0.0"},
-  "poison": {:git, "https://github.com/devinus/poison.git", "53de16a8dcb67d896d1d2b8ea91b9d506b8d83f4", [branch: "master"]}}
+%{"plug": {:hex, :plug, "1.0.0", "dfb6e50cebdde4dd338d175df9b067e8e2e3a34e8b7b61aba6f5213cf7d13000", [], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}]},
+  "poison": {:hex, :poison, "3.0.0", "625ebd64d33ae2e65201c2c14d6c85c27cc8b68f2d0dd37828fde9c6920dd131", [:mix], []}}


### PR DESCRIPTION
This PR adds an optional keyword list to be passed to the doc helper.
The motivation is to allow a custom swagger operationId to be passed through to the backend formatter.
The previous implementation assumed that the operationId was set based on the phoenix controller and action.

The implementation adds a new entry to the conn.assigns map: bureaucrat_opts which contains all the metadata from the test, including the description, line and any extra args provided at the call site.

This PR also updates the deps now that plug 1.0 is stable, and poison 3.0 has been released.