### PR TITLE
Fix Elixir 1.4 warnings

### DIFF
--- a/lib/bureaucrat/formatter.ex
+++ b/lib/bureaucrat/formatter.ex
@@ -7,7 +7,7 @@ defmodule Bureaucrat.Formatter do
 
   def handle_event({:suite_finished, _run_us, _load_us}, nil) do
     env_var = Application.get_env(:bureaucrat, :env_var)
-    if System.get_env(env_var), do: generate_docs
+    if System.get_env(env_var), do: generate_docs()
     :remove_handler
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -6,8 +6,8 @@ defmodule Bureaucrat.Mixfile do
      version: "0.1.4",
      elixir: "~> 1.0",
      description: "Generate Phoenix API documentation from tests",
-     deps: deps,
-     package: package]
+     deps: deps(),
+     package: package()]
   end
 
   # Configuration for the OTP application


### PR DESCRIPTION
Elixir 1.4 prefers empty parenthesis when calling a local function.