### PR TITLE
Support phoenix channels (websockets) documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,28 @@ end
 Then, to generate the documentation file(s) run `DOC=1 mix test`.
 The default output file is `web/controllers/README.md`.
 
+Documenting Phoenix Channels
+----------------------------
+
+Bureaucrat can also generate documentation for messages, replies and broadcasts in [Phoenix Channels](http://www.phoenixframework.org/docs/channels).
+
+Results of `assert_push`, `assert_broadcast` and the underlying `assert_receive` (if used for messages or broadcasts) can be passed to the `doc` function.
+
+To document usage of [Phoenix.ChannelTest](https://hexdocs.pm/phoenix/Phoenix.ChannelTest.html) helpers `push`, `broadcast_from` and `broadcast_from!`, Bureaucrat includes documenting alternatives, prefixed with `doc_`:
+  * `doc_push`
+  * `doc_broadcast_from`
+  * `doc_broadcast_fron!`
+
+```elixir
+test "message:new broadcasts are pushed to the client", %{socket: socket} do
+  doc_broadcast_from! socket, "message:new", %{body: "Hello there!", timestamp: 1483971926566, user: "marla"}
+  assert_push("message:new", %{body: "Hello there!", timestamp: 1483971926566, user: "marla"})
+  |> doc
+end
+```
+
+Channels docs output is currently only supported by the `Bureaucrat.MarkdownWriter` and only to the `default_path` (see [Configuration](#configuration) below).
+
 Configuration
 -------------
 

--- a/lib/bureaucrat/formatter.ex
+++ b/lib/bureaucrat/formatter.ex
@@ -20,7 +20,7 @@ defmodule Bureaucrat.Formatter do
     writer  = Application.get_env(:bureaucrat, :writer)
     grouped =
       records
-      |> Enum.sort_by(&(-1 * &1.assigns.bureaucrat_line))
+      |> Enum.sort_by(&line_for/1)
       |> group_by_path
 
     Enum.map(grouped, fn {path, recs} ->
@@ -28,12 +28,16 @@ defmodule Bureaucrat.Formatter do
     end)
   end
 
+  defp line_for({_, opts}), do: opts[:line]
+  defp line_for(conn), do: -1 * conn.assigns.bureaucrat_line
+
   defp group_by_path(records) do
     default_path = Application.get_env(:bureaucrat, :default_path)
     paths = Application.get_env(:bureaucrat, :paths)
     Enum.group_by(records, &(path_for(&1, paths, default_path)))
   end
 
+  defp path_for({_, _}, _, default_path), do: default_path
   defp path_for(_record, [], default_path), do: default_path
   defp path_for(record, [{prefix, path} | paths], default_path) do
     module = record.private.phoenix_controller

--- a/lib/bureaucrat/helpers.ex
+++ b/lib/bureaucrat/helpers.ex
@@ -1,4 +1,5 @@
 defmodule Bureaucrat.Helpers do
+  alias Phoenix.Socket.{Broadcast, Message, Reply}
 
   @doc """
   Adds a conn to the generated documentation.
@@ -8,6 +9,48 @@ defmodule Bureaucrat.Helpers do
   defmacro doc(conn) do
     quote bind_quoted: [conn: conn] do
       doc(conn, [])
+    end
+  end
+
+  @doc """
+  Adds a Phoenix.Socket.Message to the generated documentation.
+
+  The name of the test currently being executed will be used as a description for the example.
+  """
+  defmacro doc_push(socket, event) do
+    quote bind_quoted: [socket: socket, event: event] do
+      ref = make_ref()
+      message = %Message{event: event, topic: socket.topic, ref: ref, payload: Phoenix.ChannelTest.__stringify__(%{})}
+      doc(message, [])
+      send(socket.channel_pid, message)
+      ref
+    end
+  end
+  defmacro doc_push(socket, event, payload) do
+    quote bind_quoted: [socket: socket, event: event, payload: payload] do
+      ref = make_ref()
+      message = %Message{event: event, topic: socket.topic, ref: ref, payload: Phoenix.ChannelTest.__stringify__(payload)}
+      doc(message, [])
+      send(socket.channel_pid, message)
+      ref
+    end
+  end
+
+  defmacro doc_broadcast_from(socket, event, message) do
+    quote bind_quoted: [socket: socket, event: event, message: message] do
+      %{pubsub_server: pubsub_server, topic: topic, transport_pid: transport_pid} = socket
+      broadcast = %Broadcast{topic: topic, event: event, payload: message}
+      doc(broadcast, [])
+      Phoenix.Channel.Server.broadcast_from pubsub_server, transport_pid, topic, event, message
+    end
+  end
+
+  defmacro doc_broadcast_from!(socket, event, message) do
+    quote bind_quoted: [socket: socket, event: event, message: message] do
+      %{pubsub_server: pubsub_server, topic: topic, transport_pid: transport_pid} = socket
+      broadcast = %Broadcast{topic: topic, event: event, payload: message}
+      doc(broadcast, [])
+      Phoenix.Channel.Server.broadcast_from! pubsub_server, transport_pid, topic, event, message
     end
   end
 
@@ -33,12 +76,14 @@ defmodule Bureaucrat.Helpers do
   end
 
   defmacro doc(conn, opts) when is_list(opts) do
+    mod  = __CALLER__.module
     fun  = __CALLER__.function |> elem(0) |> to_string
     line = __CALLER__.line
 
     opts =
       opts
       |> Keyword.put_new(:description, format_test_name(fun))
+      |> Keyword.put(:module, mod)
       |> Keyword.put(:line, line)
 
     quote bind_quoted: [conn: conn, opts: opts] do

--- a/lib/bureaucrat/markdown_writer.ex
+++ b/lib/bureaucrat/markdown_writer.ex
@@ -12,24 +12,25 @@ defmodule Bureaucrat.MarkdownWriter do
   defp write_table_of_contents(records, file) do
     Enum.each(records, fn {controller, actions} ->
       anchor = to_anchor(controller)
-      puts(file, "* [#{controller}](##{anchor})")
+      puts(file, "  * [#{controller}](##{anchor})")
       Enum.each(actions, fn {action, _} ->
-        anchor = to_anchor("#{controller}.#{action}")
-        puts(file, "  * [#{action}](##{anchor})")
+        anchor = to_anchor(controller, action)
+        puts(file, "    * [#{action}](##{anchor})")
       end)
     end)
     puts(file, "")
   end
 
   defp write_controller(controller, records, file) do
-    puts(file, "## #{to_string(controller)}")
+    puts(file, "## #{controller}")
     Enum.each(records, fn {action, records} ->
       write_action(action, controller, records, file)
     end)
   end
 
   defp write_action(action, controller, records, file) do
-    puts(file, "### #{controller}.#{action}")
+    anchor = to_anchor(controller, action)
+    puts(file, "### <a id=#{anchor}></a>#{action}")
     Enum.each(records, &(write_example(&1, file)))
   end
 
@@ -163,10 +164,11 @@ defmodule Bureaucrat.MarkdownWriter do
     end
   end
 
+  defp to_anchor(controller, action), do: to_anchor("#{controller}.#{action}")
   defp to_anchor(name) do
     name
     |> String.downcase
-    |> String.replace(".", "")
+    |> String.replace(".", "-")
   end
 
   defp group_records(records) do

--- a/lib/bureaucrat/markdown_writer.ex
+++ b/lib/bureaucrat/markdown_writer.ex
@@ -33,6 +33,50 @@ defmodule Bureaucrat.MarkdownWriter do
     Enum.each(records, &(write_example(&1, file)))
   end
 
+  defp write_example({%Phoenix.Socket.Broadcast{topic: topic, payload: payload, event: event} = reply, _}, file) do
+    file
+    |> puts("#### Broadcast")
+    |> puts("* __Topic:__ #{topic}")
+    |> puts("* __Event:__ #{event}")
+
+    if payload != %{} do
+      file
+      |> puts("* __Body:__")
+      |> puts("```json")
+      |> puts("#{format_body_params(payload)}")
+      |> puts("```")
+    end
+  end
+
+  defp write_example({%Phoenix.Socket.Message{topic: topic, payload: payload, event: event} = reply, _}, file) do
+    file
+    |> puts("#### Message")
+    |> puts("* __Topic:__ #{topic}")
+    |> puts("* __Event:__ #{event}")
+
+    if payload != %{} do
+      file
+      |> puts("* __Body:__")
+      |> puts("```json")
+      |> puts("#{format_body_params(payload)}")
+      |> puts("```")
+    end
+  end
+
+  defp write_example({%Phoenix.Socket.Reply{topic: topic, payload: payload, status: status} = reply, _}, file) do
+    file
+    |> puts("#### Reply")
+    |> puts("* __Status:__ #{status}")
+
+    if payload != %{} do
+      file
+      |> puts("* __Body:__")
+      |> puts("```json")
+      |> puts("#{format_body_params(payload)}")
+      |> puts("```")
+    end
+  end
+
   defp write_example(record, file) do
     path = case record.query_string do
       "" -> record.request_path
@@ -126,9 +170,15 @@ defmodule Bureaucrat.MarkdownWriter do
   end
 
   defp group_records(records) do
-    by_controller = Enum.group_by(records, &(strip_ns(&1.private.phoenix_controller)))
+    by_controller = Enum.group_by(records, &get_controller/1)
     Enum.map(by_controller, fn {c, recs} ->
-      {c, Enum.group_by(recs, &(&1.private.phoenix_action))}
+      {c, Enum.group_by(recs, &get_action/1)}
     end)
   end
+
+  defp get_controller({_, opts}), do: strip_ns(opts[:module])
+  defp get_controller(conn), do: strip_ns(conn.private.phoenix_controller)
+
+  defp get_action({_, opts}), do: opts[:description]
+  defp get_action(conn), do: conn.private.phoenix_action
 end

--- a/lib/bureaucrat/recorder.ex
+++ b/lib/bureaucrat/recorder.ex
@@ -1,8 +1,22 @@
 defmodule Bureaucrat.Recorder do
   use GenServer
 
+  alias Phoenix.Socket.{Broadcast, Message, Reply}
+
   def start_link do
     {:ok, _} = GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def doc(%Broadcast{} = broadcast, opts) do
+    GenServer.cast(__MODULE__, {:channel_doc, broadcast, opts})
+  end
+
+  def doc(%Message{} = message, opts) do
+    GenServer.cast(__MODULE__, {:channel_doc, message, opts})
+  end
+
+  def doc(%Reply{} = reply, opts) do
+    GenServer.cast(__MODULE__, {:channel_doc, reply, opts})
   end
 
   def doc(conn, opts) do
@@ -25,6 +39,10 @@ defmodule Bureaucrat.Recorder do
       |> Plug.Conn.assign(:bureaucrat_opts, opts)
 
     {:noreply, [conn | records]}
+  end
+
+  def handle_cast({:channel_doc, message, opts}, records) do
+    {:noreply, [{message, opts} | records]}
   end
 
   def handle_call(:get_records, _from, records) do

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule Bureaucrat.Mixfile do
   defp deps do
     [
      {:plug, "~> 1.0"},
-     {:poison, "~> 3.0"}
+     {:poison, "~> 1.5 or ~> 2.0 or ~> 3.0"}
     ]
   end
 


### PR DESCRIPTION
This implements generating documentation for Phoenix Channels messages, replies and broadcasts as suggested in #14. Connecting the socket and joining channels is not included yet.

Also, I've loosened the version constraint on poison (it's now in line with [phoenix](https://hex.pm/packages/phoenix/1.2.1)).

And I've fixed generating anchors and the table of contents in the `Bureaucrat.MarkdownWriter`.

There's still room for refactoring. But I'd need to test this against `Bureaucrat.SwaggerSlateMarkdownWriter`, which is currently not documented (and I haven't used it yet) -> #15.