### PR TITLE
Add optional phoenix dependency, Fix compiler warnings, Fix channel anchor links

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ defmodule Spell.ConnCase do
 end
 ```
 
+To generate Phoenix channel documentation, import the helpers in `test/support/channel_case.ex` alike.
+
 Usage
 -----
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Results of `assert_push`, `assert_broadcast` and the underlying `assert_receive`
 To document usage of [Phoenix.ChannelTest](https://hexdocs.pm/phoenix/Phoenix.ChannelTest.html) helpers `push`, `broadcast_from` and `broadcast_from!`, Bureaucrat includes documenting alternatives, prefixed with `doc_`:
   * `doc_push`
   * `doc_broadcast_from`
-  * `doc_broadcast_fron!`
+  * `doc_broadcast_from!`
 
 ```elixir
 test "message:new broadcasts are pushed to the client", %{socket: socket} do

--- a/lib/bureaucrat/helpers.ex
+++ b/lib/bureaucrat/helpers.ex
@@ -1,5 +1,5 @@
 defmodule Bureaucrat.Helpers do
-  alias Phoenix.Socket.{Broadcast, Message, Reply}
+  alias Phoenix.Socket.{Broadcast, Message}
 
   @doc """
   Adds a conn to the generated documentation.

--- a/lib/bureaucrat/markdown_writer.ex
+++ b/lib/bureaucrat/markdown_writer.ex
@@ -34,7 +34,7 @@ defmodule Bureaucrat.MarkdownWriter do
     Enum.each(records, &(write_example(&1, file)))
   end
 
-  defp write_example({%Phoenix.Socket.Broadcast{topic: topic, payload: payload, event: event} = reply, _}, file) do
+  defp write_example({%Phoenix.Socket.Broadcast{topic: topic, payload: payload, event: event}, _}, file) do
     file
     |> puts("#### Broadcast")
     |> puts("* __Topic:__ #{topic}")
@@ -49,7 +49,7 @@ defmodule Bureaucrat.MarkdownWriter do
     end
   end
 
-  defp write_example({%Phoenix.Socket.Message{topic: topic, payload: payload, event: event} = reply, _}, file) do
+  defp write_example({%Phoenix.Socket.Message{topic: topic, payload: payload, event: event}, _}, file) do
     file
     |> puts("#### Message")
     |> puts("* __Topic:__ #{topic}")
@@ -64,7 +64,7 @@ defmodule Bureaucrat.MarkdownWriter do
     end
   end
 
-  defp write_example({%Phoenix.Socket.Reply{topic: topic, payload: payload, status: status} = reply, _}, file) do
+  defp write_example({%Phoenix.Socket.Reply{payload: payload, status: status}, _}, file) do
     file
     |> puts("#### Reply")
     |> puts("* __Status:__ #{status}")
@@ -168,7 +168,7 @@ defmodule Bureaucrat.MarkdownWriter do
   defp to_anchor(name) do
     name
     |> String.downcase
-    |> String.replace(".", "-")
+    |> String.replace(~r/\W+/, "-")
   end
 
   defp group_records(records) do

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,8 @@ defmodule Bureaucrat.Mixfile do
   defp deps do
     [
      {:plug, "~> 1.0"},
-     {:poison, "~> 1.5 or ~> 2.0 or ~> 3.0"}
+     {:poison, "~> 1.5 or ~> 2.0 or ~> 3.0"},
+     {:phoenix, "~> 1.2", optional: true}
     ]
   end
 


### PR DESCRIPTION
When I recompiled my project from scratch with the added channels support, the compiler didn't recognize the Phoenix modules. While at it, I also fixed compiler warnings and made anchor links generation much more robust.