### PR TITLE
Add custom intro section, Preserve test order

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ end
 Then, to generate the documentation file(s) run `DOC=1 mix test`.
 The default output file is `web/controllers/README.md`.
 
+### Custom intro sections
+
+To add a custom intro section, for each output file, bureaucrat will look for an __intro markdown file__ in the output directory,
+named like the output file with a `_intro` or `_INTRO` suffix (before `.md`, if present), e.g.
+
+  * `web/controllers/README` -> `web/controllers/README_INTRO`
+  * `web/controllers/readme.md` -> `web/controllers/readme_intro.md`
+
+Currently only supported by the (default) `Bureaucrat.MarkdownWriter`.
+
 Documenting Phoenix Channels
 ----------------------------
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Bureaucrat.start(
  writer: Bureaucrat.MarkdownWriter,
  default_path: "web/controllers/README.md",
  paths: [],
+ titles: [],
  env_var: "DOC"
 )
 ```

--- a/README.md
+++ b/README.md
@@ -130,4 +130,7 @@ connections.
 For example `[{YourApp.Api.V1, "web/controllers/api/v1/README.md"}]` will
 cause the docs for controllers under `YourApp.Api.V1` namespace to
 be written to `web/controllers/api/v1/README.md`.
+* `:titles`: Allows you to specify explicit titles for some of your modules.
+For example `[{YourApp.Api.V1.UserController, "API /v1/users"}]` will
+change the title (Table of Contents entry and heading) for this controller.
 * `:env_var`: The environment variable used as a flag to trigger doc generation.

--- a/lib/bureaucrat/formatter.ex
+++ b/lib/bureaucrat/formatter.ex
@@ -20,7 +20,7 @@ defmodule Bureaucrat.Formatter do
     writer  = Application.get_env(:bureaucrat, :writer)
     grouped =
       records
-      |> Enum.sort_by(&line_for/1)
+      |> Enum.sort_by(&sort_item_for/1)
       |> group_by_path
 
     Enum.map(grouped, fn {path, recs} ->
@@ -28,8 +28,8 @@ defmodule Bureaucrat.Formatter do
     end)
   end
 
-  defp line_for({_, opts}), do: opts[:line]
-  defp line_for(conn), do: -1 * conn.assigns.bureaucrat_line
+  defp sort_item_for({_, opts}), do: {opts[:file], opts[:line]}
+  defp sort_item_for(conn), do: {conn.assigns.bureaucrat_file, conn.assigns.bureaucrat_line}
 
   defp group_by_path(records) do
     default_path = Application.get_env(:bureaucrat, :default_path)

--- a/lib/bureaucrat/helpers.ex
+++ b/lib/bureaucrat/helpers.ex
@@ -83,9 +83,12 @@ defmodule Bureaucrat.Helpers do
     file = __CALLER__.file  # full path as binary
     line = __CALLER__.line
 
+    titles = Application.get_env(:bureaucrat, :titles)
+
     opts =
       opts
       |> Keyword.put_new(:description, format_test_name(fun))
+      |> Keyword.put_new(:group_title, group_title_for(mod, titles))
       |> Keyword.put(:module, mod)
       |> Keyword.put(:file, file)
       |> Keyword.put(:line, line)
@@ -97,4 +100,13 @@ defmodule Bureaucrat.Helpers do
   end
 
   def format_test_name("test " <> name), do: name
+
+  def group_title_for(mod, []), do: nil
+  def group_title_for(mod, [{other, path} | paths]) do
+    if String.replace_suffix(to_string(mod), "Test", "") == to_string(other) do
+      path
+    else
+      group_title_for(mod, paths)
+    end
+  end
 end

--- a/lib/bureaucrat/helpers.ex
+++ b/lib/bureaucrat/helpers.ex
@@ -76,14 +76,18 @@ defmodule Bureaucrat.Helpers do
   end
 
   defmacro doc(conn, opts) when is_list(opts) do
+    # __CALLER__returns a `Macro.Env` struct
+    #   -> https://hexdocs.pm/elixir/Macro.Env.html
     mod  = __CALLER__.module
     fun  = __CALLER__.function |> elem(0) |> to_string
+    file = __CALLER__.file  # full path as binary
     line = __CALLER__.line
 
     opts =
       opts
       |> Keyword.put_new(:description, format_test_name(fun))
       |> Keyword.put(:module, mod)
+      |> Keyword.put(:file, file)
       |> Keyword.put(:line, line)
 
     quote bind_quoted: [conn: conn, opts: opts] do

--- a/lib/bureaucrat/markdown_writer.ex
+++ b/lib/bureaucrat/markdown_writer.ex
@@ -39,8 +39,7 @@ defmodule Bureaucrat.MarkdownWriter do
   end
 
   defp write_controller(controller, records, file) do
-    anchor = to_anchor(controller)
-    puts(file, "## <a id=#{anchor}></a>#{controller}")
+    puts(file, "## #{controller}")
     Enum.each(records, fn {action, records} ->
       write_action(action, controller, records, file)
     end)

--- a/lib/bureaucrat/markdown_writer.ex
+++ b/lib/bureaucrat/markdown_writer.ex
@@ -39,7 +39,8 @@ defmodule Bureaucrat.MarkdownWriter do
   end
 
   defp write_controller(controller, records, file) do
-    puts(file, "## #{controller}")
+    anchor = to_anchor(controller)
+    puts(file, "## <a id=#{anchor}></a>#{controller}")
     Enum.each(records, fn {action, records} ->
       write_action(action, controller, records, file)
     end)
@@ -186,6 +187,8 @@ defmodule Bureaucrat.MarkdownWriter do
     name
     |> String.downcase
     |> String.replace(~r/\W+/, "-")
+    |> String.replace_leading("-", "")
+    |> String.replace_trailing("-", "")
   end
 
   defp group_records(records) do
@@ -195,8 +198,8 @@ defmodule Bureaucrat.MarkdownWriter do
     end)
   end
 
-  defp get_controller({_, opts}), do: strip_ns(opts[:module])
-  defp get_controller(conn), do: strip_ns(conn.private.phoenix_controller)
+  defp get_controller({_, opts}), do: opts[:group_title] || strip_ns(opts[:module])
+  defp get_controller(conn), do: conn.assigns.bureaucrat_opts[:group_title] || strip_ns(conn.private.phoenix_controller)
 
   defp get_action({_, opts}), do: opts[:description]
   defp get_action(conn), do: conn.private.phoenix_action

--- a/lib/bureaucrat/markdown_writer.ex
+++ b/lib/bureaucrat/markdown_writer.ex
@@ -191,7 +191,7 @@ defmodule Bureaucrat.MarkdownWriter do
   defp group_records(records) do
     by_controller = Enum.group_by(records, &get_controller/1)
     Enum.map(by_controller, fn {c, recs} ->
-      {c, Enum.group_by(recs, &get_action/1)}
+      {c, Bureaucrat.Util.stable_group_by(recs, &get_action/1)}
     end)
   end
 

--- a/lib/bureaucrat/markdown_writer.ex
+++ b/lib/bureaucrat/markdown_writer.ex
@@ -189,7 +189,7 @@ defmodule Bureaucrat.MarkdownWriter do
   end
 
   defp group_records(records) do
-    by_controller = Enum.group_by(records, &get_controller/1)
+    by_controller = Bureaucrat.Util.stable_group_by(records, &get_controller/1)
     Enum.map(by_controller, fn {c, recs} ->
       {c, Bureaucrat.Util.stable_group_by(recs, &get_action/1)}
     end)

--- a/lib/bureaucrat/recorder.ex
+++ b/lib/bureaucrat/recorder.ex
@@ -35,6 +35,7 @@ defmodule Bureaucrat.Recorder do
     conn =
       conn
       |> Plug.Conn.assign(:bureaucrat_desc, opts[:description])
+      |> Plug.Conn.assign(:bureaucrat_file, opts[:file])
       |> Plug.Conn.assign(:bureaucrat_line, opts[:line])
       |> Plug.Conn.assign(:bureaucrat_opts, opts)
 

--- a/lib/bureaucrat/util.ex
+++ b/lib/bureaucrat/util.ex
@@ -1,0 +1,30 @@
+defmodule Bureaucrat.Util do
+  @moduledoc """
+  Some functions used across Bureaucrat internally
+  """
+
+  @doc """
+  Takes a list of pre-sorted entries and groups them by given function,
+  but returns a list of tuples `[{k, v}, ...]` instead of a Map to preserve
+  key sort order, which can be given to Enum functions identically.
+
+  Implementation inspired by `Enum.group_by/3`
+    -> https://github.com/elixir-lang/elixir/blob/v1.4.2/lib/elixir/lib/enum.ex#L1036
+  """
+  def stable_group_by(enumerable, key_fun, value_fun \\ fn x -> x end)
+      when is_function(key_fun, 1) and is_function(value_fun, 1) do
+    Enum.reduce(Enum.reverse(enumerable), [], fn entry, categories ->
+      key = key_fun.(entry)
+      value = value_fun.(entry)
+
+      case categories do
+        # key matches previous key -> add value to previous list
+        [{^key, values} | tail] ->
+          [{key, [value | values]} | tail]
+        # otherwise -> start a new list with this value
+        _ ->
+          [{key, [value]} | categories]
+      end
+    end)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -20,6 +20,7 @@ defmodule Bureaucrat.Mixfile do
         writer: Bureaucrat.MarkdownWriter,
         default_path: "web/controllers/README.md",
         paths: [],
+        titles: [],
         env_var: "DOC"
       ]]
   end


### PR DESCRIPTION
I've made two more changes:

1. New feature to include a markdown file as intro section for each output file, determined by output file path and name (e.g. `web/controllers/API_INTRO.md` for `web/controllers/API.md`). It's included before the table of contents (which then automatically gets the header `Endpoints`). We use this to document how to connect to the API and the different environments.

2. The formatter sorts the records by the line in the file it was recorded in. However, the sort order was lost due to the nature of Map keys (sorted for "small" maps) when using `Enum.group_by/2`. Thus, I've made a `stable_group_by/2` alternative that does the same but preserves sort order, and use it in the `MarkdownWriter`. This is particularly useful to document channels, as often tests represent sequences of messages. @mbuhot I've left the `SwaggerSlateMarkdownWriter` as it is, as I don't know whether swagger favors alphabetic or the sort order in which tests were run - feel free to change it alike if you think it makes sense here as well.

Hope these changes are in line with what you like to see for bureaucrat :)