### PR TITLE
Formatter should be a GenServer.

### DIFF
--- a/lib/bureaucrat/formatter.ex
+++ b/lib/bureaucrat/formatter.ex
@@ -1,18 +1,19 @@
 defmodule Bureaucrat.Formatter do
-  use GenEvent
+  use GenServer
 
   def init(_config) do
     {:ok, nil}
   end
 
-  def handle_event({:suite_finished, _run_us, _load_us}, nil) do
+  def handle_cast({:suite_finished, _run_us, _load_us}, nil) do
     env_var = Application.get_env(:bureaucrat, :env_var)
     if System.get_env(env_var), do: generate_docs()
-    :remove_handler
+
+    {:noreply, nil}
   end
 
-  def handle_event(_event, nil) do
-    {:ok, nil}
+  def handle_cast(_event, nil) do
+    {:noreply, nil}
   end
 
   defp generate_docs do


### PR DESCRIPTION
GenEvent is deprecated.

> warning: passing GenEvent handlers (Bureaucrat.Formatter in this case) in the :formatters option of ExUnit is deprecated, please pass a GenServer instead. Check the documentation for the ExUnit.Formatter module for more information