### PR TITLE
Fix response section title

### DIFF
--- a/lib/bureaucrat/markdown_writer.ex
+++ b/lib/bureaucrat/markdown_writer.ex
@@ -129,6 +129,7 @@ defmodule Bureaucrat.MarkdownWriter do
     end
 
     file
+    |> puts("")
     |> puts("##### Response")
     |> puts("* __Status__: #{record.status}")
 


### PR DESCRIPTION
The sections `Request` and  `Response` should be separated by a new line to keep the proper markdown format.