### PR TITLE
write parameters should handle lists as well as maps

### DIFF
--- a/lib/bureaucrat/swagger_slate_markdown_writer.ex
+++ b/lib/bureaucrat/swagger_slate_markdown_writer.ex
@@ -263,7 +263,7 @@ eg by passing it as an option to the Bureaucrat.start/1 function.
   Uses the vendor extension "x-example" to provide example of each parameter.
   TODO: detailed schema validation rules aren't shown yet (min/max/regex/etc...)
   """
-  def write_parameters(file, _ = %{"parameters" => params}) when map_size(params) > 0 do
+  def write_parameters(file, _ = %{"parameters" => params}) when length(params) > 0 or map_size(params) > 0 do
     file
     |> puts("#### Parameters\n")
     |> puts("| Parameter   | Description | In |Type      | Required | Default | Example |")


### PR DESCRIPTION
Using swagger to generate API documentation, the parameters field is not generated as a map.  When swagger_slate_markdown_writer calls write_parameters, the method to update the parameters in the file never triggers because of the guard clause ` map_size(params) > 0`.

This pr updates that guard clause to accept lists as well as maps, and now the markdown_writer works as the documentation implies.