### PR TITLE
Sort records in ApiBlueprintWriter

### DIFF
--- a/lib/bureaucrat/api_blueprint_writer.ex
+++ b/lib/bureaucrat/api_blueprint_writer.ex
@@ -166,5 +166,6 @@ defmodule Bureaucrat.ApiBlueprintWriter do
     |> Enum.map(fn {controller_name, records} ->
       {controller_name, Enum.group_by(records, & &1.private.phoenix_action)}
     end)
+    |> Enum.sort
   end
 end


### PR DESCRIPTION
We had a couple of API documentation readers that weren't satisfied with the randomness of the examples in the API documentation.

This small pull request fixes the issue as it alphabetically sorts all the records before printing out the markdown.