### PR TITLE
Fix an issue when documenting Phoenix Channels

### DIFF
--- a/lib/bureaucrat/markdown_writer.ex
+++ b/lib/bureaucrat/markdown_writer.ex
@@ -198,7 +198,7 @@ defmodule Bureaucrat.MarkdownWriter do
     end)
   end
 
-  defp get_controller({_, opts}), do: opts[:group_title] || strip_ns(opts[:module])
+  defp get_controller({_, opts}), do: opts[:group_title] || String.replace_suffix(strip_ns(opts[:module]), "Test", "")
   defp get_controller(conn), do: conn.assigns.bureaucrat_opts[:group_title] || strip_ns(conn.private.phoenix_controller)
 
   defp get_action({_, opts}), do: opts[:description]


### PR DESCRIPTION
There is an error when I try to document phoenix channels which comes from  `validate_records/1` function. This function assumes that all records have `private` attribute which is not true for `Phoenix.Socket.Message` struct and etc. 

This PR fixes this issue by refactoring `validate_records/1` to be able to handle all record types not just `Plug.Conn` struct

```
11:55:12.690 [error] GenServer #PID<0.395.0> terminating
** (ArgumentError) argument error
    :erlang.apply(%Phoenix.Socket.Message{event: "subscribe", join_ref: nil, payload: %{result: []}, ref: nil, topic: "orders"}, :private, [])
    (bureaucrat) lib/bureaucrat/formatter.ex:54: anonymous fn/1 in Bureaucrat.Formatter.validate_records/1
    (elixir) lib/enum.ex:1294: Enum."-map/2-lists^map/1-0-"/2
    (bureaucrat) lib/bureaucrat/formatter.ex:54: Bureaucrat.Formatter.validate_records/1
    (bureaucrat) lib/bureaucrat/formatter.ex:21: Bureaucrat.Formatter.generate_docs/0
    (bureaucrat) lib/bureaucrat/formatter.ex:10: Bureaucrat.Formatter.handle_cast/2
    (stdlib) gen_server.erl:616: :gen_server.try_dispatch/4
    (stdlib) gen_server.erl:686: :gen_server.handle_msg/6
    (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
Last message: {:"$gen_cast", {:suite_finished, 1461346, nil}}
11:55:12.709 [error] Task #PID<0.382.0> started from #PID<0.73.0> terminating
** (stop) exited in: GenServer.stop(#PID<0.395.0>, :normal, 30000)
    ** (EXIT) no process: the process is not alive or there's no process currently associated with the given name, possibly because its application isn't started
    (elixir) lib/gen_server.ex:795: GenServer.stop/3
    (ex_unit) lib/ex_unit/event_manager.ex:21: anonymous fn/2 in ExUnit.EventManager.stop/1
    (elixir) lib/enum.ex:1899: Enum."-reduce/3-lists^foldl/2-0-"/3
    (ex_unit) lib/ex_unit/event_manager.ex:20: ExUnit.EventManager.stop/1
    (ex_unit) lib/ex_unit/runner.ex:21: ExUnit.Runner.run/2
    (elixir) lib/task/supervised.ex:88: Task.Supervised.do_apply/2
    (elixir) lib/task/supervised.ex:38: Task.Supervised.reply/5
    (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
Function: &ExUnit.run/0
    Args: []
11:55:12.710 [error] GenServer #PID<0.391.0> terminating
** (stop) exited in: GenServer.stop(#PID<0.395.0>, :normal, 30000)
    ** (EXIT) no process: the process is not alive or there's no process currently associated with the given name, possibly because its application isn't started
Last message: {:EXIT, #PID<0.382.0>, {:noproc, {GenServer, :stop, [#PID<0.395.0>, :normal, 30000]}}}
11:55:12.710 [error] GenServer #PID<0.226.0> terminating
** (stop) exited in: GenServer.stop(#PID<0.395.0>, :normal, 30000)
    ** (EXIT) no process: the process is not alive or there's no process currently associated with the given name, possibly because its application isn't started
Last message: {:EXIT, #PID<0.73.0>, {:noproc, {GenServer, :stop, [#PID<0.395.0>, :normal, 30000]}}}
```