### PR TITLE
Support generate doc when join a topic

### DIFF
--- a/lib/bureaucrat/markdown_writer.ex
+++ b/lib/bureaucrat/markdown_writer.ex
@@ -95,7 +95,7 @@ defmodule Bureaucrat.MarkdownWriter do
     end
   end
 
-  defp write_example({status, payload, %Phoenix.Socket{} = socket}, file) do
+  defp write_example({{status, payload, %Phoenix.Socket{} = socket}, _}, file) do
     file
     |> puts("#### Join")
     |> puts("* __Topic:__ #{socket.topic}")

--- a/lib/bureaucrat/markdown_writer.ex
+++ b/lib/bureaucrat/markdown_writer.ex
@@ -99,8 +99,7 @@ defmodule Bureaucrat.MarkdownWriter do
     file
     |> puts("#### Join")
     |> puts("* __Topic:__ #{socket.topic}")
-    |> puts("* __Event:__ receive")
-    |> puts("* __Status:__ #{status}")
+    |> puts("* __Receive:__ #{status}")
 
     if payload != %{} do
       file

--- a/lib/bureaucrat/markdown_writer.ex
+++ b/lib/bureaucrat/markdown_writer.ex
@@ -95,11 +95,28 @@ defmodule Bureaucrat.MarkdownWriter do
     end
   end
 
-  defp write_example(record, file) do
-    path = case record.query_string do
-      "" -> record.request_path
-      str -> "#{record.request_path}?#{str}"
+  defp write_example({status, payload, %Phoenix.Socket{} = socket}, file) do
+    file
+    |> puts("#### Join")
+    |> puts("* __Topic:__ #{socket.topic}")
+    |> puts("* __Event:__ receive")
+    |> puts("* __Status:__ #{status}")
+
+    if payload != %{} do
+      file
+      |> puts("* __Body:__")
+      |> puts("```json")
+      |> puts("#{format_body_params(payload)}")
+      |> puts("```")
     end
+  end
+
+  defp write_example(record, file) do
+    path =
+      case record.query_string do
+        "" -> record.request_path
+        str -> "#{record.request_path}?#{str}"
+      end
 
     file
     |> puts("#### #{record.assigns.bureaucrat_desc}")

--- a/lib/bureaucrat/recorder.ex
+++ b/lib/bureaucrat/recorder.ex
@@ -1,6 +1,7 @@
 defmodule Bureaucrat.Recorder do
   use GenServer
 
+  alias Phoenix.Socket
   alias Phoenix.Socket.{Broadcast, Message, Reply}
 
   def start_link do
@@ -17,6 +18,10 @@ defmodule Bureaucrat.Recorder do
 
   def doc(%Reply{} = reply, opts) do
     GenServer.cast(__MODULE__, {:channel_doc, reply, opts})
+  end
+
+  def doc({_, _, %Socket{}} = join_socket, opts) do
+    GenServer.cast(__MODULE__, {:channel_doc, join_socket, opts})
   end
 
   def doc(conn, opts) do


### PR DESCRIPTION
When we join a topic. We can reply message to client synchronously. (https://hexdocs.pm/phoenix/channels.html)


```
join :: {:ok, reply, socket}
```

Currently, Bureaucrat cannot generate document according to the reply above.


## Propose
```elixir
  describe "join" do
    test "returns payload correctly", %{socket: socket} do
      result = subscribe_and_join(socket, RoomChannel, "room:lobby")

      assert  { :ok, %{ payload: "example" }, _ } = result
        |> doc
    end
  end
```

### Output

#### Join
* __Topic:__ room:lobby
* __Receive:__ ok
* __Body:__
... body payload


