### PR TITLE
JSON library is now configurable. Defaults to Poison.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ defp deps do
 end
 ```
 
+Bureaucrat needs a json library and defaults to Poison. It must be added as a dependency:
+
+```elixir
+defp deps do
+  [
+    {:bureaucrat, "~> 0.2.4"},
+    {:poison, "~> 3.0"}
+  ]
+end
+```
+
 Then, update your dependencies:
 
 ```
@@ -217,7 +228,8 @@ Bureaucrat.start(
  default_path: "web/controllers/README.md",
  paths: [],
  titles: [],
- env_var: "DOC"
+ env_var: "DOC",
+ json_library: Poison
 )
 ```
 
@@ -235,3 +247,4 @@ For example `[{YourApp.Api.V1.UserController, "API /v1/users"}]` will
 change the title (Table of Contents entry and heading) for this controller.
 * `:prefix`: Allows you to remove the prefix of the test module names
 * `:env_var`: The environment variable used as a flag to trigger doc generation.
+* `:json_library`: The JSON library to use. Poison (the default) and Jason both work.

--- a/lib/bureaucrat/api_blueprint_writer.ex
+++ b/lib/bureaucrat/api_blueprint_writer.ex
@@ -1,4 +1,6 @@
 defmodule Bureaucrat.ApiBlueprintWriter do
+  alias Bureaucrat.JSON
+
   def write(records, path) do
     file = File.open!(path, [:write, :utf8])
     records = group_records(records)
@@ -110,7 +112,7 @@ defmodule Bureaucrat.ApiBlueprintWriter do
   end
 
   def format_request_body(params) do
-    {:ok, json} = Poison.encode(params, pretty: true)
+    {:ok, json} = JSON.encode(params, pretty: true)
     json
   end
 
@@ -119,8 +121,8 @@ defmodule Bureaucrat.ApiBlueprintWriter do
   end
 
   defp format_response_body(string) do
-    {:ok, struct} = Poison.decode(string)
-    {:ok, json} = Poison.encode(struct, pretty: true)
+    {:ok, struct} = JSON.decode(string)
+    {:ok, json} = JSON.encode(struct, pretty: true)
     json
   end
 

--- a/lib/bureaucrat/json.ex
+++ b/lib/bureaucrat/json.ex
@@ -1,0 +1,28 @@
+defmodule Bureaucrat.JSON do
+  @moduledoc """
+  Wrapper around the configured JSON library.
+  The default is Poison, but it can be configured to e.g. Jason with:
+
+      config :bureaucrat, :json_library, Jason
+  """
+
+  def encode(value, options \\ []) do
+    json_library().encode(value, options)
+  end
+
+  def encode!(value, options \\ []) do
+    json_library().encode!(value, options)
+  end
+
+  def decode(value, options \\ []) do
+    json_library().decode(value, options)
+  end
+
+  def decode!(value, options \\ []) do
+    json_library().decode!(value, options)
+  end
+
+  defp json_library do
+    Application.get_env(:bureaucrat, :json_library, Poison)
+  end
+end

--- a/lib/bureaucrat/markdown_writer.ex
+++ b/lib/bureaucrat/markdown_writer.ex
@@ -1,4 +1,6 @@
 defmodule Bureaucrat.MarkdownWriter do
+  alias Bureaucrat.JSON
+
   def write(records, path) do
     {:ok, file} = File.open path, [:write, :utf8]
     records = group_records(records)
@@ -172,7 +174,7 @@ defmodule Bureaucrat.MarkdownWriter do
   end
 
   def format_body_params(params) do
-    {:ok, json} = Poison.encode(params, pretty: true)
+    {:ok, json} = JSON.encode(params, pretty: true)
     json
   end
 
@@ -181,8 +183,8 @@ defmodule Bureaucrat.MarkdownWriter do
   end
 
   defp format_resp_body(string) do
-    {:ok, struct} = Poison.decode(string)
-    {:ok, json} = Poison.encode(struct, pretty: true)
+    {:ok, struct} = JSON.decode(string)
+    {:ok, json} = JSON.encode(struct, pretty: true)
     json
   end
 

--- a/lib/bureaucrat/swagger_slate_markdown_writer.ex
+++ b/lib/bureaucrat/swagger_slate_markdown_writer.ex
@@ -5,6 +5,7 @@ It requires that the decoded swagger data be available via Application.get_env(:
 eg by passing it as an option to the Bureaucrat.start/1 function.
 """
 
+  alias Bureaucrat.JSON
   alias Plug.Conn
 
   # pipeline-able puts
@@ -112,7 +113,7 @@ eg by passing it as an option to the Bureaucrat.start/1 function.
   end
 
   def write_model_example(file, %{"example" => example}) do
-    json = Poison.encode!(example, pretty: true)
+    json = JSON.encode!(example, pretty: true)
     file
     |> puts("\n```json")
     |> puts(json)
@@ -281,8 +282,8 @@ eg by passing it as an option to the Bureaucrat.start/1 function.
   end
   def write_parameters(file, _), do: file
 
-  # Encode parameter table cell values as strings, using Poison to convert lists/maps
-  defp encode_parameter_table_cell(param) when is_map(param) or is_list(param), do: Poison.encode!(param)
+  # Encode parameter table cell values as strings, using json library to convert lists/maps
+  defp encode_parameter_table_cell(param) when is_map(param) or is_list(param), do: JSON.encode!(param)
   defp encode_parameter_table_cell(param), do: to_string(param)
 
   @doc """
@@ -326,7 +327,7 @@ eg by passing it as an option to the Bureaucrat.start/1 function.
     unless record.body_params == %{} do
       file
       |> puts("```json")
-      |> puts("#{Poison.encode!(record.body_params, pretty: true)}")
+      |> puts("#{JSON.encode!(record.body_params, pretty: true)}")
       |> puts("```\n")
     end
 
@@ -361,7 +362,7 @@ eg by passing it as an option to the Bureaucrat.start/1 function.
   def format_resp_body(string) do
     case string do
       "" -> ""
-      _ -> string |> Poison.decode! |> Poison.encode!(pretty: true)
+      _ -> string |> JSON.decode!() |> JSON.encode!(pretty: true)
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule Bureaucrat.Mixfile do
   defp deps do
     [
      {:plug, ">= 1.0.0"},
-     {:poison, "~> 1.5 or ~> 2.0 or ~> 3.0"},
+     {:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", optional: true},
      {:phoenix, ">= 1.2.0", optional: true},
      {:ex_doc, ">= 0.0.0", only: :dev},
      {:inflex, ">= 1.10.0"}


### PR DESCRIPTION
Closes #43 

I'm not sure how to include a test of this, since there are no existing tests.

I have tried it in my own app, and it works as expected when `Jason` is the configured json library.
Only difference in the json output is that `Jason` seems to sort fields of an object alphabetically with `pretty: true`.