### PR TITLE
Setting a default operation ID

### DIFF
--- a/lib/bureaucrat/helpers.ex
+++ b/lib/bureaucrat/helpers.ex
@@ -96,6 +96,10 @@ defmodule Bureaucrat.Helpers do
       |> Keyword.put(:line, line)
 
     quote bind_quoted: [conn: conn, opts: opts] do
+      opts =
+        opts
+        |> Keyword.put_new(:operation_id, default_operation_id(conn))
+
       Bureaucrat.Recorder.doc(conn, opts)
       conn
     end
@@ -137,5 +141,12 @@ defmodule Bureaucrat.Helpers do
     conn
     |> Plug.Conn.put_private(:phoenix_controller, controller_name)
     |> Plug.Conn.put_private(:phoenix_action, action)
+  end
+
+  defp default_operation_id(conn) do
+    %{phoenix_controller: elixir_controller, phoenix_action: action} = conn.private
+    controller = elixir_controller |> to_string() |> String.trim("Elixir.")
+
+    "#{controller}.#{action}"
   end
 end


### PR DESCRIPTION
`phoenix_swagger` sets a default operation_id when none is given, based
on the controller & action name

This change takes advantage of that by setting that same operation_id on
every `doc/1` call

Using the slate writer, this operation_id is mandatory on every `doc/1`
call, so this prevents us from having to set it on both sides just for
this purpose