### PR TITLE
Fixed pattern matching error in api_blueprint_writer

### DIFF
--- a/lib/bureaucrat.ex
+++ b/lib/bureaucrat.ex
@@ -2,11 +2,7 @@ defmodule Bureaucrat do
   use Application
 
   def start(_type, []) do
-    import Supervisor.Spec
-
-    children = [
-      worker(Bureaucrat.Recorder, [])
-    ]
+    children = [Bureaucrat.Recorder]
 
     opts = [strategy: :one_for_one, name: Bureaucrat.Supervisor]
     Supervisor.start_link(children, opts)

--- a/lib/bureaucrat/recorder.ex
+++ b/lib/bureaucrat/recorder.ex
@@ -3,9 +3,8 @@ defmodule Bureaucrat.Recorder do
 
   alias Phoenix.Socket
   alias Phoenix.Socket.{Broadcast, Message, Reply}
-  alias Bureaucrat.Recorder.ConnPreprocessor
 
-  def start_link do
+  def start_link([]) do
     {:ok, _} = GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
 


### PR DESCRIPTION
* Fixed the pattern matching errors in the api_blueprint_writer `write_parameters` and `write_response_body` functions.

    * The pattern `params = %{}` matches any map, but the cases where it was used should have been matching an empty map. This resulted in the parameters not being registered.

* Updated the `anchor` function in api_blueprint_writer to print the correct key name, instead of always using "id", and to support multiple path params keys.
* updated how Bureaucrat.Recorder is called, removing the call to the deprecated Supervisor.Spec