### PR TITLE
Fixing for exunit >= 1.12

### DIFF
--- a/lib/bureaucrat/formatter.ex
+++ b/lib/bureaucrat/formatter.ex
@@ -6,13 +6,21 @@ defmodule Bureaucrat.Formatter do
   end
 
   def handle_cast({:suite_finished, _run_us, _load_us}, nil) do
-    env_var = Application.get_env(:bureaucrat, :env_var)
-    if System.get_env(env_var), do: generate_docs()
+    suite_finished()
+  end
 
-    {:noreply, nil}
+  def handle_cast({:suite_finished, _times_us}, nil) do
+    suite_finished()
   end
 
   def handle_cast(_event, nil) do
+    {:noreply, nil}
+  end
+
+  defp suite_finished() do
+    env_var = Application.get_env(:bureaucrat, :env_var)
+    if System.get_env(env_var), do: generate_docs()
+
     {:noreply, nil}
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Bureaucrat.Mixfile do
   def project do
     [
       app: :bureaucrat,
-      version: "0.2.7",
+      version: "0.2.8",
       elixir: "~> 1.6 or ~> 1.7",
       description: "Generate Phoenix API documentation from tests",
       deps: deps(),


### PR DESCRIPTION
between https://hexdocs.pm/ex_unit/1.11.4/ExUnit.Formatter.html

and https://hexdocs.pm/ex_unit/1.12.0/ExUnit.Formatter.html

it looks like the suite_finished events have changed.
to ensure backwards compatibility - both messages are captured.