### PR TITLE
Added `detail` to opts

### DIFF
--- a/lib/bureaucrat/api_blueprint_writer.ex
+++ b/lib/bureaucrat/api_blueprint_writer.ex
@@ -53,7 +53,9 @@ defmodule Bureaucrat.ApiBlueprintWriter do
     record_request = Enum.at(records, 0)
     method = record_request.method
 
-    file |> puts("### #{test_description} [#{method} #{anchor(record_request)}]")
+    file
+    |> puts("### #{test_description} [#{method} #{anchor(record_request)}]")
+    |> puts("\n\n #{Keyword.get(record_request.assigns.bureaucrat_opts, :detail, "")}")
 
     write_parameters(record_request.path_params, file)
 

--- a/lib/bureaucrat/markdown_writer.ex
+++ b/lib/bureaucrat/markdown_writer.ex
@@ -132,6 +132,7 @@ defmodule Bureaucrat.MarkdownWriter do
 
     file
     |> puts("#### #{record.assigns.bureaucrat_desc}")
+    |> puts("#{Keyword.get(record.assigns.bureaucrat_opts, :detail, "")}")
     |> puts("##### Request")
     |> puts("* __Method:__ #{record.method}")
     |> puts("* __Path:__ #{path}")


### PR DESCRIPTION
Hi I added a new `bureaucrat_opts` called `detail`. 
This new opts is added, if present, after the `description` opts, only in the `Bureaucrat.MarkdownWriter` and `Bureaucrat.ApiBlueprintWriter` writers.

An example of use: 

```elixir
  ...
  |> doc(
   description: "Create a new Worklist",
   detail: """
   Markdown example
  
   - item 1
   - item 2
   """)
```


