### PR TITLE
Add ID fetcher from socket Reply operation

### DIFF
--- a/lib/bureaucrat/helpers.ex
+++ b/lib/bureaucrat/helpers.ex
@@ -1,5 +1,5 @@
 defmodule Bureaucrat.Helpers do
-  alias Phoenix.Socket.{Broadcast, Message}
+  alias Phoenix.Socket.{Broadcast, Message, Reply}
 
   @doc """
   Adds a conn to the generated documentation.
@@ -132,6 +132,10 @@ defmodule Bureaucrat.Helpers do
 
   def get_default_operation_id(%Broadcast{topic: topic, event: event}) do
     "#{topic}.#{event}"
+  end
+
+  def get_default_operation_id(%Reply{topic: topic}) do
+    "#{topic}.reply"
   end
 
   @doc """


### PR DESCRIPTION
Original [commit][1] missing the case when `Phoenix.Socket.Reply` send back to the socket and documented via `doc`.

Example code:

```
    ref =
      doc_push(socket, "update", %{
        "score" => score
      })

    assert_reply(ref, :ok, data) |> doc
```

After an upgrade from `0.2.7` to the latest version as it was suggested in [issue][2] Reply was broken.

[1]: https://github.com/api-hogs/bureaucrat/commit/e9cce6e03b60c933a9aa3d34bb2a6b3a9c6f193d
[2]: https://github.com/api-hogs/bureaucrat/issues/71#issuecomment-913838455