### PR TITLE
fix helper to make join connection doc work

### DIFF
--- a/lib/bureaucrat/helpers.ex
+++ b/lib/bureaucrat/helpers.ex
@@ -1,5 +1,6 @@
 defmodule Bureaucrat.Helpers do
   alias Phoenix.Socket.{Broadcast, Message, Reply}
+  alias Phoenix.Socket
 
   @doc """
   Adds a conn to the generated documentation.
@@ -136,6 +137,10 @@ defmodule Bureaucrat.Helpers do
 
   def get_default_operation_id(%Reply{topic: topic}) do
     "#{topic}.reply"
+  end
+
+  def get_default_operation_id({_, _, %Socket{endpoint: endpoint}}) do
+    "#{endpoint}.reply"
   end
 
   @doc """


### PR DESCRIPTION
Hello 

This is a fix of helper.ex to be able to document the join to a channel

```elixir
{:ok, reply, socket } = Socket(module, socket_id, socket_assigns |> subscribe_and_join(topic, params) |> doc
```
This is a fix since the "Join" section already exists in the MarkdownWriter.

