### PR TITLE
add helpers doc_connect to document a connect operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,9 @@ Bureaucrat can also generate documentation for messages, replies and broadcasts 
 
 Results of `assert_push`, `assert_broadcast` and the underlying `assert_receive` (if used for messages or broadcasts) can be passed to the `doc` function.
 
-To document usage of [Phoenix.ChannelTest](https://hexdocs.pm/phoenix/Phoenix.ChannelTest.html) helpers `push`, `broadcast_from` and `broadcast_from!`, Bureaucrat includes documenting alternatives, prefixed with `doc_`:
+To document usage of [Phoenix.ChannelTest](https://hexdocs.pm/phoenix/Phoenix.ChannelTest.html) helpers `connect`, `push`, `broadcast_from` and `broadcast_from!`, Bureaucrat includes documenting alternatives, prefixed with `doc_`:
 
+- `doc_connect`
 - `doc_push`
 - `doc_broadcast_from`
 - `doc_broadcast_from!`

--- a/lib/bureaucrat/helpers.ex
+++ b/lib/bureaucrat/helpers.ex
@@ -1,6 +1,5 @@
 defmodule Bureaucrat.Helpers do
   alias Phoenix.Socket.{Broadcast, Message, Reply}
-  alias Phoenix.Socket
 
   @doc """
   Adds a conn to the generated documentation.
@@ -10,6 +9,29 @@ defmodule Bureaucrat.Helpers do
   defmacro doc(conn) do
     quote bind_quoted: [conn: conn] do
       doc(conn, [])
+    end
+  end
+
+  @doc """
+  Adds a Phoenix.Socket connection to the generated documentation.
+
+  The name of the test currently being executed will be used as a description for the example.
+  """
+  defmacro doc_connect(
+             handler,
+             params,
+             connect_info \\ quote(do: %{})
+           ) do
+    if endpoint = Module.get_attribute(__CALLER__.module, :endpoint) do
+      quote do
+        {status, socket} =
+          unquote(Phoenix.ChannelTest).__connect__(unquote(endpoint), unquote(handler), unquote(params), unquote(connect_info))
+
+        doc({status, socket, unquote(handler), unquote(params), unquote(connect_info)})
+        {status, socket}
+      end
+    else
+      raise "module attribute @endpoint not set for socket/2"
     end
   end
 
@@ -142,6 +164,11 @@ defmodule Bureaucrat.Helpers do
   def get_default_operation_id({_, _, %Socket{endpoint: endpoint}}) do
     "#{endpoint}.reply"
   end
+
+  def get_default_operation_id({_, %Socket{endpoint: endpoint}, _, _, _}) do
+    "#{endpoint}.connect"
+  end
+
 
   @doc """
   Helper function for adding the phoenix_controller and phoenix_action keys to

--- a/lib/bureaucrat/markdown_writer.ex
+++ b/lib/bureaucrat/markdown_writer.ex
@@ -123,6 +123,21 @@ defmodule Bureaucrat.MarkdownWriter do
     end
   end
 
+  defp write_example({{status, %Phoenix.Socket{}, _handler, params, _connect_info}, _}, file) do
+    # for connect
+    file
+    |> puts("#### Connect")
+
+    if params != %{} do
+      file
+      |> puts("* __Body:__")
+      |> puts("```json")
+      |> puts("#{format_body_params(params)}")
+      |> puts("```")
+    end
+    |> puts("* __Receive:__ #{status}")
+  end
+
   defp write_example(record, file) do
     path =
       case record.query_string do

--- a/lib/bureaucrat/recorder.ex
+++ b/lib/bureaucrat/recorder.ex
@@ -24,6 +24,10 @@ defmodule Bureaucrat.Recorder do
     GenServer.cast(__MODULE__, {:channel_doc, join_socket, opts})
   end
 
+  def doc({_, %Socket{}, _, _, _} = connect_socket, opts) do
+    GenServer.cast(__MODULE__, {:channel_doc, connect_socket, opts})
+  end
+
   def doc(conn, opts) do
     GenServer.cast(__MODULE__, {:doc, conn, opts})
   end


### PR DESCRIPTION
Hello 

I propose a new helper 'doc_connect'  in helper. 
Like the `doc_push` I copied the original `connect` macro of Phoenix.ChannelTest, to add a doc record with the params, and the result of `__connect__`. 

I'm not sure I choose the more relevant `default_operation_id`, not the best output format in the documentation. 
I'm open to better suggestions.

Regards 

