### PR TITLE
Bureaucrat macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The default output file is `API.md` in the project root.
 If you don't want to call `|> doc()` on each request, you can import `Bureaucrat.Macros`.
 
 - It automatically adds `|> doc()` to the `Phoenix.ConnTest` macros
-- It creates other macros: `get_undocumented`, `post_undocumented`, `patch_undocumented`, `put_undocumented` and `delete_undocumented`, to be used in requests you want to skip docs.
+- It creates other macros: `get_undocumented`, `post_undocumented`, `patch_undocumented`, `put_undocumented` and `delete_undocumented`, to be used in requests you want to skip docs
 
 You can also use the `_undocumented` version to overcome the fact that `|> doc()` can only be called
 from a test block, not a private function.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,29 @@ end
 Then, to generate the documentation file(s) run `DOC=1 mix test`.
 The default output file is `API.md` in the project root.
 
+### Pipe `|> doc()` automatically
+If you don't want to call `|> doc()` on each request, you can import `Bureaucrat.Macros`.
+
+- It automatically adds `|> doc()` to the `Phoenix.ConnTest` macros
+- It creates other macros: `get_undocumented`, `post_undocumented`, `patch_undocumented`, `put_undocumented` and `delete_undocumented`, to be used in requests you want to skip docs.
+
+You can also use the `_undocumented` version to overcome the fact that `|> doc()` can only be called
+from a test block, not a private function.
+
+To achieve this, replace
+
+```elixir
+import Phoenix.ConnTest
+```
+
+By
+
+```elixir
+import Phoenix.ConnTest, only: :functions
+import Bureaucrat.Helpers
+import Bureaucrat.Macros
+```
+
 ### Custom intro sections
 
 To add a custom intro section, for each output file, bureaucrat will look for an **intro markdown file** in the output directory,

--- a/lib/bureaucrat/macros.ex
+++ b/lib/bureaucrat/macros.ex
@@ -1,0 +1,112 @@
+defmodule Bureaucrat.Macros do
+  @moduledoc """
+  Implements `Phoenix.ConnTest` macros with `&Bureaucrat.Helpers.doc/1` support.
+  When `Phoenix.ConnTest` macros (get, post, put...) are called, `doc` helper is automatically called after.
+  If you don't wish to document a certain request, use `get_undocumented` or any other `_undocumented` macro.
+  It automatically skips documentation if halted by a Plug.
+
+  When a request is called from inside a private function instead of a test block, `Bureaucrat` can't
+  find the test name to use on the documentation, and raises. In this case, use the `_undocumented`
+  version to bypass the documentation, or send the request from the test block instead of private function.
+
+  - Automatically documents: get, post, put, patch and delete requests
+  - Skips documentation for: options, connect, trace and head requests
+  - Implements: get_undocumented, post_undocumented, put_undocumented, patch_undocumented and delete_undocumented.
+
+  ## Usage
+
+  On `ConnCase` file, change this
+
+      import Phoenix.ConnTest
+
+  To
+
+      import Phoenix.ConnTest, only: :functions
+      import Bureaucrat.Helpers
+      import Bureaucrat.Macros
+  """
+
+  @doc_http_methods [:get, :post, :put, :patch, :delete]
+  @undoc_http_methods [:options, :connect, :trace, :head]
+
+  for method <- @doc_http_methods do
+    @doc """
+    Dispatches test request with documentation.
+    Documents: get, post, put, patch and delete requests.
+    """
+    defmacro unquote(method)(conn, path_or_action, params_or_body \\ nil) do
+      method = unquote(method)
+
+      quote do
+        conn =
+          Phoenix.ConnTest.dispatch(
+            unquote(conn),
+            @endpoint,
+            unquote(method),
+            unquote(path_or_action),
+            unquote(params_or_body)
+          )
+
+        accept_header = conn |> Plug.Conn.get_req_header("accept") |> List.first() || ""
+        content_header = conn |> Plug.Conn.get_resp_header("content-type") |> List.first() || ""
+        is_json = Enum.any?([accept_header, content_header], &String.contains?(&1, "json"))
+
+        if is_json do
+          try do
+            doc(conn)
+          rescue
+            # Bureaucrat fails to get controller/action when request is halted from a plug.
+            # In this case, we skip documentation. Here is the reason:
+            # https://github.com/api-hogs/bureaucrat/blob/8ac7efd04dafdedfe986ba0032e7cb1cbac1df5d/lib/bureaucrat/helpers.ex#L147
+            e in MatchError ->
+              conn
+          end
+        else
+          conn
+        end
+      end
+    end
+  end
+
+  for method <- @doc_http_methods do
+    @doc """
+    Dispatches test request without documentation.
+    Implements: get_undocumented, post_undocumented, put_undocumented, ..., macros to skip doc.
+    """
+    method_name = String.to_atom("#{method}_undocumented")
+
+    defmacro unquote(method_name)(conn, path_or_action, params_or_body \\ nil) do
+      method = unquote(method)
+
+      quote do
+        Phoenix.ConnTest.dispatch(
+          unquote(conn),
+          @endpoint,
+          unquote(method),
+          unquote(path_or_action),
+          unquote(params_or_body)
+        )
+      end
+    end
+  end
+
+  for method <- @undoc_http_methods do
+    @doc """
+    Dispatches test request without documentation.
+    Skips documentation for: options, connect, trace and head requests
+    """
+    defmacro unquote(method)(conn, path_or_action, params_or_body \\ nil) do
+      method = unquote(method)
+
+      quote do
+        Phoenix.ConnTest.dispatch(
+          unquote(conn),
+          @endpoint,
+          unquote(method),
+          unquote(path_or_action),
+          unquote(params_or_body)
+        )
+      end
+    end
+  end
+end

--- a/test/macros_test.exs
+++ b/test/macros_test.exs
@@ -1,0 +1,71 @@
+# Inspired by `Phoenix.Test.ConnTest`
+
+defmodule Bureaucrat.MacrosTest.CatchAll do
+  def init(opts), do: opts
+  def call(conn, _opts), do: conn
+end
+
+defmodule Bureaucrat.MacrosTest.Router do
+  use Phoenix.Router
+  scope("/", do: forward("/", Bureaucrat.MacrosTest.CatchAll))
+end
+
+defmodule Bureaucrat.MacrosTest do
+  use ExUnit.Case, async: false
+  import Phoenix.ConnTest, only: :functions
+  import Bureaucrat.Helpers
+  import Bureaucrat.Macros
+  alias Bureaucrat.MacrosTest.Router
+  alias Bureaucrat.Recorder
+
+  @moduletag :capture_log
+  Application.put_env(:phoenix, Bureaucrat.MacrosTest.Endpoint, [])
+
+  defmodule Endpoint do
+    use Phoenix.Endpoint, otp_app: :phoenix
+    def init(opts), do: opts
+    def call(conn, :set), do: resp(conn, 200, "ok")
+
+    def call(conn, opts) do
+      put_in(super(conn, opts).private[:endpoint], opts)
+      |> Router.call(Router.init([]))
+    end
+  end
+
+  @endpoint Endpoint
+
+  setup_all do
+    Endpoint.start_link()
+    :ok
+  end
+
+  setup _context do
+    Application.stop(:bureaucrat)
+    Bureaucrat.start()
+
+    conn =
+      build_conn()
+      |> Plug.Conn.put_req_header("accept", "application/json")
+      |> Plug.Conn.put_private(:phoenix_controller, FooController)
+      |> Plug.Conn.put_private(:phoenix_action, :bar)
+
+    {:ok, conn: conn}
+  end
+
+  for method <- [:get, :post, :put, :delete] do
+    @method method
+    test "#{method} macro records connection", %{conn: conn} do
+      assert [] = Recorder.get_records()
+      unquote(@method)(conn, "/hello", %{foo: "bar"})
+      assert [_conn] = Recorder.get_records()
+    end
+  end
+
+  for method <- [:get_undocumented, :post_undocumented, :put_undocumented, :delete_undocumented, :options, :connect, :trace, :head] do
+    @method method
+    test "#{method} macro does not record connection", %{conn: conn} do
+      unquote(@method)(conn, "/hello", %{foo: "bar"})
+      assert [] = Recorder.get_records()
+    end
+  end
+end


### PR DESCRIPTION
Implement a way for `|> doc()` to be called automatically.
Added to readme and tested.
This is useful for huge applications that want to add `Bureaucrat` and can't afford to add `|> doc()` to every test.