### PR TITLE
Add error messages

### DIFF
--- a/lib/bureaucrat/helpers.ex
+++ b/lib/bureaucrat/helpers.ex
@@ -133,6 +133,13 @@ defmodule Bureaucrat.Helpers do
 
   def format_test_name("test " <> name), do: name
 
+  def format_test_name(function_name),
+    do: raise("It looks like you called a `Phoenix.ConnTest` macro inside `#{function_name}`.
+        Bureaucrat can only document macros `get`, `post`, `delete`, etc. when they are called inside a `test` block.
+
+        If the request macro is called inside a private function or setup, you should explicitly say you don't want Bureaucrat to document this request.
+        Use `get_undocumented`, `post_undocumented`, `delete_undocumented`, `patch_undocumented` or `put_undocumented` instead.")
+
   def group_title_for(_mod, []), do: nil
 
   def group_title_for(mod, [{other, path} | paths]) do

--- a/lib/bureaucrat/helpers.ex
+++ b/lib/bureaucrat/helpers.ex
@@ -144,10 +144,16 @@ defmodule Bureaucrat.Helpers do
   end
 
   def get_default_operation_id(%Plug.Conn{private: private}) do
-    %{phoenix_controller: elixir_controller, phoenix_action: action} = private
-    controller = elixir_controller |> to_string() |> String.trim("Elixir.")
+    case private do
+      %{phoenix_controller: elixir_controller, phoenix_action: action} ->
+        controller = elixir_controller |> to_string() |> String.trim("Elixir.")
+        "#{controller}.#{action}"
 
-    "#{controller}.#{action}"
+      _ ->
+        raise "Bureaucrat couldn't find a controller and/or action for this request.
+            Possibly, the request is halted by a plug before it gets to the controller.
+            Please use `get_undocumented` or `post_undocumented` (etc.) instead."
+    end
   end
 
   def get_default_operation_id(%Message{topic: topic, event: event}) do

--- a/lib/bureaucrat/helpers.ex
+++ b/lib/bureaucrat/helpers.ex
@@ -133,12 +133,15 @@ defmodule Bureaucrat.Helpers do
 
   def format_test_name("test " <> name), do: name
 
-  def format_test_name(function_name),
-    do: raise("It looks like you called a `Phoenix.ConnTest` macro inside `#{function_name}`.
-        Bureaucrat can only document macros `get`, `post`, `delete`, etc. when they are called inside a `test` block.
+  def format_test_name(function_name) do
+    raise """
+    It looks like you called a `Phoenix.ConnTest` macro inside `#{function_name}`.
+    Bureaucrat can only document macros `get`, `post`, `delete`, etc. when they are called inside a `test` block.
 
-        If the request macro is called inside a private function or setup, you should explicitly say you don't want Bureaucrat to document this request.
-        Use `get_undocumented`, `post_undocumented`, `delete_undocumented`, `patch_undocumented` or `put_undocumented` instead.")
+    If the request macro is called inside a private function or setup, you should explicitly say you don't want Bureaucrat to document this request.
+    Use `get_undocumented`, `post_undocumented`, `delete_undocumented`, `patch_undocumented` or `put_undocumented` instead.
+    """
+  end
 
   def group_title_for(_mod, []), do: nil
 
@@ -157,9 +160,11 @@ defmodule Bureaucrat.Helpers do
         "#{controller}.#{action}"
 
       _ ->
-        raise "Bureaucrat couldn't find a controller and/or action for this request.
-            Possibly, the request is halted by a plug before it gets to the controller.
-            Please use `get_undocumented` or `post_undocumented` (etc.) instead."
+        raise """
+        Bureaucrat couldn't find a controller and/or action for this request.
+        Possibly, the request is halted by a plug before it gets to the controller.
+        Please use `get_undocumented` or `post_undocumented` (etc.) instead.
+        """
     end
   end
 

--- a/lib/bureaucrat/helpers.ex
+++ b/lib/bureaucrat/helpers.ex
@@ -156,8 +156,7 @@ defmodule Bureaucrat.Helpers do
   def get_default_operation_id(%Plug.Conn{private: private}) do
     case private do
       %{phoenix_controller: elixir_controller, phoenix_action: action} ->
-        controller = elixir_controller |> to_string() |> String.trim("Elixir.")
-        "#{controller}.#{action}"
+        "#{inspect(elixir_controller)}.#{action}"
 
       _ ->
         raise """

--- a/test/macros_test.exs
+++ b/test/macros_test.exs
@@ -116,11 +116,11 @@ defmodule Bureaucrat.MacrosTest do
 
             @endpoint false
 
-            test "mock test that will fail" do
-              foo()
+            test "won't compile because it calls Phoenix.ConnTest.#{unquote(@method)} in private function" do
+              private_caller()
             end
 
-            defp foo() do
+            defp private_caller() do
               unquote(@method)(:fake_conn, "/hello", %{foo: "bar"})
             end
           end
@@ -128,7 +128,7 @@ defmodule Bureaucrat.MacrosTest do
 
       error = assert_raise RuntimeError, fn -> Code.eval_quoted(ast) end
 
-      assert error.message =~ "It looks like you called a `Phoenix.ConnTest` macro inside `foo`."
+      assert error.message =~ "It looks like you called a `Phoenix.ConnTest` macro inside `private_caller`."
     end
   end
 end

--- a/test/macros_test.exs
+++ b/test/macros_test.exs
@@ -96,4 +96,39 @@ defmodule Bureaucrat.MacrosTest do
       assert error.message =~ "Bureaucrat couldn't find a controller and/or action for this request"
     end
   end
+
+  # We want to raise an error when Phoenix.ConnTest macros are called outside a `test` block.
+  # This test mimics a userland test that calls Phoenix.ConnTest.{get, post, put, delete}
+  # and asserts that a RuntimeError is raised when compiling the code.
+  # This is counterintuitive, but remember that some of Bureaucrat's runtime is during test compilation.
+  for method <- [:get, :post, :put, :delete] do
+    @method method
+    test "Raises runtime error with message when calling #{@method} outside a `test` block" do
+      module_name = :"RuntimeErrorTest#{@method |> Atom.to_string() |> Macro.camelize()}"
+
+      ast =
+        quote do
+          defmodule unquote(module_name) do
+            use ExUnit.Case, async: false
+            import Phoenix.ConnTest, only: :functions
+            import Bureaucrat.Helpers
+            import Bureaucrat.Macros
+
+            @endpoint false
+
+            test "mock test that will fail" do
+              foo()
+            end
+
+            defp foo() do
+              unquote(@method)(:fake_conn, "/hello", %{foo: "bar"})
+            end
+          end
+        end
+
+      error = assert_raise RuntimeError, fn -> Code.eval_quoted(ast) end
+
+      assert error.message =~ "It looks like you called a `Phoenix.ConnTest` macro inside `foo`."
+    end
+  end
 end


### PR DESCRIPTION
This PR adds two error messages that have cost our team a bit of time while we debugged. Hopefully they will save others some time!

Here are the two cases that we ran into, which we raised verbose errors for:
1. `phoenix_controller` and `phoenix_action`
    - **DESCRIPTION**: When the Plug doesn't have a `phoenix_controller` and `phoenix_action`, it will fail. This happened for us when a Plug halted the `conn` early, in our case because of authentication. It failed with an opaque `MatchError`. 
    - **FIX**: This PR raises a verbose error if the keys are missing in `Plug.Conn.private`.
    - **TESTS**: The tests previously included cases where  `phoenix_controller` and `phoenix_action` were manually added to the `conn`. This PR adds tests without those, to prove that when they're missing, a correct `RuntimeError` is raised instead of the `MatchError`.
3. `Phoenix.ConnTest` macros
     - **DESCRIPTION**:   If a user called a `Phoenix.ConnTest` macro (`get, push, post, delete`) anywhere other than directly inside a `test` block, Bureaucrat would raise a `FunctionClauseError` at compile time. This is because we match on the string `"test "` to get the name of a test. So if a user put a request inside a private function, it would fail.
     - **FIX** This PR includes a default case for when the function name doesn't start with `"test "` which raises a verbose error.
     - **TESTS**: This PR includes a test that (bear with me) defines a test module in a macro, then compiles that macro and asserts that when compiling, the correct `RuntimeError` is raised.

Please let me know if you have any questions.