### PR TITLE
Support doc from functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,6 @@ If you don't want to call `|> doc()` on each request, you can import `Bureaucrat
 - It automatically adds `|> doc()` to the `Phoenix.ConnTest` macros
 - It creates other macros: `get_undocumented`, `post_undocumented`, `patch_undocumented`, `put_undocumented` and `delete_undocumented`, to be used in requests you want to skip docs
 
-You can also use the `_undocumented` version to overcome the fact that `|> doc()` can only be called
-from a test block, not a private function.
-
 To achieve this, replace
 
 ```elixir

--- a/lib/bureaucrat/helpers.ex
+++ b/lib/bureaucrat/helpers.ex
@@ -127,7 +127,27 @@ defmodule Bureaucrat.Helpers do
         |> Keyword.put_new(:operation_id, default_operation_id)
         |> Keyword.update!(:description, &(&1 || default_description()))
 
-      Bureaucrat.Recorder.doc(conn, opts)
+      if Keyword.fetch!(opts, :description) != nil do
+        Bureaucrat.Recorder.doc(conn, opts)
+      else
+        file = Keyword.fetch!(opts, :file)
+        line = Keyword.fetch!(opts, :line)
+
+        Mix.shell().info("""
+        The request at #{file}:#{line} won't be recorded by bureaucrat because
+        the description can't be determined and none is explicitly provided.
+        To address this, you can pass the :description option to this macro.
+
+        If this macro is invoked indirectly, via the request macros, such as
+        get and post, you can switch to the _undocumented version to
+        explicitly avoid generating the documentation.
+
+        Alternatively, you can provide the description manually with something
+        like doc(conn, description: "some description"), where conn is the result
+        of the _undocumented macro.
+        """)
+      end
+
       conn
     end
   end

--- a/lib/bureaucrat/helpers.ex
+++ b/lib/bureaucrat/helpers.ex
@@ -153,8 +153,13 @@ defmodule Bureaucrat.Helpers do
   end
 
   def default_description do
-    # We look for the first test process in the stack traces of this process as well as other callers.
-    # The latter allows us to find the test description even if this function is running in a task started by a test process.
+    # The default description is taken from the test which invoked this code (if such test exists).
+    # We'll first look into the call stack of this process. If we can't find a test function, we'll
+    # look at the $callers process dictionary entry, which contains the pids of caller processes.
+    # This allows us to find the owner test even if this function is running in a separate task
+    # process. See https://hexdocs.pm/elixir/Task.html#module-ancestor-and-caller-tracking for
+    # details.
+
     callers = Process.get(:"$callers") || []
     Enum.find_value([self() | callers], &test_description/1)
   end

--- a/lib/bureaucrat/helpers.ex
+++ b/lib/bureaucrat/helpers.ex
@@ -132,16 +132,7 @@ defmodule Bureaucrat.Helpers do
   end
 
   def format_test_name("test " <> name), do: name
-
-  def format_test_name(function_name) do
-    raise """
-    It looks like you called a `Phoenix.ConnTest` macro inside `#{function_name}`.
-    Bureaucrat can only document macros `get`, `post`, `delete`, etc. when they are called inside a `test` block.
-
-    If the request macro is called inside a private function or setup, you should explicitly say you don't want Bureaucrat to document this request.
-    Use `get_undocumented`, `post_undocumented`, `delete_undocumented`, `patch_undocumented` or `put_undocumented` instead.
-    """
-  end
+  def format_test_name(_other), do: nil
 
   def group_title_for(_mod, []), do: nil
 

--- a/test/macros_test.exs
+++ b/test/macros_test.exs
@@ -110,6 +110,17 @@ defmodule Bureaucrat.MacrosTest do
       assert conn.assigns.bureaucrat_desc == "description is generated when the request is made from another function"
     end
 
-    defp hello_request(conn), do: get(conn, "/hello")
+    test "is not auto-generated when one is provided", context do
+      hello_request(context.conn, description: "custom description")
+      [conn] = Recorder.get_records()
+      assert conn.assigns.bureaucrat_desc == "custom description"
+    end
+
+    defp hello_request(conn, opts \\ []) do
+      case Keyword.fetch(opts, :description) do
+        :error -> get(conn, "/hello")
+        {:ok, description} -> conn |> get_undocumented("/hello") |> doc(description: description)
+      end
+    end
   end
 end

--- a/test/macros_test.exs
+++ b/test/macros_test.exs
@@ -107,7 +107,7 @@ defmodule Bureaucrat.MacrosTest do
     test "is generated when the request is made from another function", context do
       hello_request(context.conn)
       [conn] = Recorder.get_records()
-      assert conn.assigns.bureaucrat_desc == nil
+      assert conn.assigns.bureaucrat_desc == "description is generated when the request is made from another function"
     end
 
     defp hello_request(conn), do: get(conn, "/hello")

--- a/test/macros_test.exs
+++ b/test/macros_test.exs
@@ -110,6 +110,18 @@ defmodule Bureaucrat.MacrosTest do
       assert conn.assigns.bureaucrat_desc == "description is generated when the request is made from another function"
     end
 
+    test "is generated when the request is made from another task", context do
+      description =
+        Task.async(fn ->
+          hello_request(context.conn)
+          [conn] = Recorder.get_records()
+          conn.assigns.bureaucrat_desc
+        end)
+        |> Task.await()
+
+      assert description == "description is generated when the request is made from another task"
+    end
+
     test "is not auto-generated when one is provided", context do
       hello_request(context.conn, description: "custom description")
       [conn] = Recorder.get_records()

--- a/test/macros_test.exs
+++ b/test/macros_test.exs
@@ -131,4 +131,12 @@ defmodule Bureaucrat.MacrosTest do
       assert error.message =~ "It looks like you called a `Phoenix.ConnTest` macro inside `private_caller`."
     end
   end
+
+  describe "description" do
+    test "is generated from a test description", context do
+      get(context.conn, "/hello")
+      [conn] = Recorder.get_records()
+      assert conn.assigns.bureaucrat_desc == "description is generated from a test description"
+    end
+  end
 end

--- a/test/macros_test.exs
+++ b/test/macros_test.exs
@@ -128,24 +128,30 @@ defmodule Bureaucrat.MacrosTest do
       assert conn.assigns.bureaucrat_desc == "custom description"
     end
 
-    test "is not auto-generated if the test is not in a call stack", context do
-      test_pid = self()
-
-      spawn(fn ->
-        hello_request(context.conn)
-        [conn] = Recorder.get_records()
-        send(test_pid, {:description, conn.assigns.bureaucrat_desc})
-      end)
-
-      assert_receive {:description, description}
-      assert description == nil
-    end
-
     defp hello_request(conn, opts \\ []) do
       case Keyword.fetch(opts, :description) do
         :error -> get(conn, "/hello")
         {:ok, description} -> conn |> get_undocumented("/hello") |> doc(description: description)
       end
     end
+  end
+
+  test "request is not recorded if the test is not in a call stack", context do
+    test_pid = self()
+
+    captured_io =
+      ExUnit.CaptureIO.capture_io(fn ->
+        spawn(fn ->
+          hello_request(context.conn)
+
+          records = Recorder.get_records()
+          send(test_pid, {:recorded, records})
+        end)
+
+        assert_receive {:recorded, records}
+        assert records == []
+      end)
+
+    assert captured_io =~ ~r/The request.*won't be recorded/
   end
 end


### PR DESCRIPTION
resolves #96 

- if the caller of `doc` is not a test, `nil` is used as a default description
- if description is `nil` we search for the test caller at runtime, by looking at the stack trace of this process as well as its callers (to support invocations from tasks)
- if description is still `nil` a warning is printed and the request is not recorded

For simpler review I suggest reading one commit at a time.