### PR TITLE
Refactor write_model_properties function to handle nil values in model_schema

### DIFF
--- a/lib/bureaucrat/swagger_slate_markdown_writer.ex
+++ b/lib/bureaucrat/swagger_slate_markdown_writer.ex
@@ -140,19 +140,23 @@ defmodule Bureaucrat.SwaggerSlateMarkdownWriter do
   prefix is output before each property name to enable nested objects to be flattened.
   """
   def write_model_properties(file, swagger, model_schema, prefix \\ "") do
-    {objects, primitives} =
-      model_schema["properties"]
-      |> Enum.split_with(fn {_key, schema} -> schema["type"] == "object" end)
+    case Map.get(model_schema, "properties") do
+      nil -> file
+      properties ->
+        {objects, primitives} =
+          properties
+          |> Enum.split_with(fn {_key, schema} -> schema["type"] == "object" end)
 
-    ordered = Enum.concat(primitives, objects)
+      ordered = Enum.concat(primitives, objects)
 
-    Enum.each(ordered, fn {property, property_details} ->
-      {property_details, type} = resolve_type(swagger, property_details)
-      required? = is_required(property, model_schema)
-      write_model_property(file, swagger, "#{prefix}#{property}", property_details, type, required?)
-    end)
+      Enum.each(ordered, fn {property, property_details} ->
+        {property_details, type} = resolve_type(swagger, property_details)
+        required? = is_required(property, model_schema)
+        write_model_property(file, swagger, "#{prefix}#{property}", property_details, type, required?)
+      end)
 
-    file
+      file
+    end
   end
 
   def resolve_type(swagger, %{"$ref" => schema_ref}) do


### PR DESCRIPTION
Resolves #50 

This commit refactors the write_model_properties function to use Map.get/3 instead of the [] operator to access the "properties" key in model_schema. This change allows the function to handle nil values in model_schema without raising an exception.

The function now uses a case expression to pattern match on the result of Map.get/3 and returns the file argument if the value is nil. If the value is nil, the function proceeds with the rest of the logic as before.

The changes make the code more robust and consistent with the "Let it crash" philosophy in Erlang/Elixir, which suggests that the system should be built to handle failures by crashing and restarting processes to recover from errors.