### PR TITLE
feat: add support for req body as a list with "_json"

### DIFF
--- a/test/postman_writer_test.exs
+++ b/test/postman_writer_test.exs
@@ -72,5 +72,47 @@ defmodule Bureaucrat.PostmanWriterTest do
       assert get_in(json, ["item", Access.at(0), "item", Access.at(0), "response", Access.at(1), "status"]) ==
                "Not Found"
     end
+
+    test "writes json body as list", %{record: record} do
+      filename = "test/output/foo_bar.json"
+
+      record =
+        Map.replace!(record, :body_params, %{
+          "_json" => [
+            %{
+              "id" => "123",
+              "type" => "a_type"
+            }
+          ]
+        })
+        |> Map.replace!(:req_headers, [{"content-type", "application/json"}])
+
+      PostmanWriter.write([record], filename)
+      json = filename |> File.read!() |> JSON.decode!()
+
+      assert get_in(json, ["item", Access.at(0), "item", Access.at(0), "request", "body", "raw"]) |> JSON.decode!() ==
+               [
+                 %{
+                   "id" => "123",
+                   "type" => "a_type"
+                 },
+               ]
+    end
+
+    test "writes json body as list when empty list", %{record: record} do
+      filename = "test/output/foo_bar.json"
+
+      record =
+        Map.replace!(record, :body_params, %{
+          "_json" => []
+        })
+        |> Map.replace!(:req_headers, [{"content-type", "application/json"}])
+
+      PostmanWriter.write([record], filename)
+      json = filename |> File.read!() |> JSON.decode!()
+
+      assert get_in(json, ["item", Access.at(0), "item", Access.at(0), "request", "body", "raw"]) |> JSON.decode!() ==
+               []
+    end
   end
 end


### PR DESCRIPTION
### Before
Only accepted body as curly brace json


### After 

Accepts body with [] (through "_json"-key. As this by convention is how plug json parser accepts lists.
https://hexdocs.pm/plug/Plug.Parsers.JSON.html#content