### PR TITLE
Fix  :no_translation relates of regular expression

### DIFF
--- a/lib/bureaucrat/markdown_writer.ex
+++ b/lib/bureaucrat/markdown_writer.ex
@@ -232,7 +232,7 @@ defmodule Bureaucrat.MarkdownWriter do
   defp to_anchor(name) do
     name
     |> String.downcase()
-    |> String.replace(~r/\W+/, "-")
+    |> String.replace(~r/\W+/u, "-")
     |> String.replace_leading("-", "")
     |> String.replace_trailing("-", "")
   end


### PR DESCRIPTION
I have issue with Unicode characters:

```
16:37:13.502 pid=<0.1496.0> module=gen_server line=1373 [error] GenServer #PID<0.1496.0> terminating
** (stop) :no_translation
(stdlib 5.1.1) io.erl:103: :io.put_chars(#PID<0.1589.0>, [<<32, 32, 32, 32, 42, 32, 91, 99, 117, 114, 115, 111, 114, 58, 117, 112, 100, 97, 116, 101, 44, 32, 208, 189, 208, 181, 209, 129, 208, 186, 208, 190, 208, 187, 209, 140, 208, 186, 208, 190, 32, 208, 191, 208, 190, 208, 187, 209, 140, ...>>, 10])
    (bureaucrat 0.2.10) lib/bureaucrat/markdown_writer.ex:220: Bureaucrat.MarkdownWriter.puts/2
    (elixir 1.17.2) lib/enum.ex:987: Enum."-each/2-lists^foreach/1-0-"/2
    (bureaucrat 0.2.10) lib/bureaucrat/markdown_writer.ex:40: Bureaucrat.MarkdownWriter.write_table_of_contents/2
    (bureaucrat 0.2.10) lib/bureaucrat/markdown_writer.ex:8: Bureaucrat.MarkdownWriter.write/2
    (elixir 1.17.2) lib/enum.ex:1711: anonymous fn/3 in Enum.map/2
    (stdlib 5.1.1) maps.erl:416: :maps.fold_1/4
    (elixir 1.17.2) lib/enum.ex:2543: Enum.map/2
    (bureaucrat 0.2.10) lib/bureaucrat/formatter.ex:22: Bureaucrat.Formatter.suite_finished/0
    (stdlib 5.1.1) gen_server.erl:1103: :gen_server.try_handle_cast/3
    (stdlib 5.1.1) gen_server.erl:1165: :gen_server.handle_msg/6
    (stdlib 5.1.1) proc_lib.erl:241: :proc_lib.init_p_do_apply/3
Last message: {:"$gen_cast", {:suite_finished, %{async: nil, run: 1205498, load: nil}}}

```
I found it relates with regular expressions.
