### PR TITLE
Added detail to postman writer like Postman documentation

### DIFF
--- a/lib/bureaucrat/postman_writer.ex
+++ b/lib/bureaucrat/postman_writer.ex
@@ -43,7 +43,8 @@ defmodule Bureaucrat.PostmanWriter do
                     body: build_req_body(records, content_type),
                     header: records |> Enum.map(& &1.req_headers) |> build_key_value(),
                     method: records |> List.first() |> Map.get(:method),
-                    url: build_url(records)
+                    url: build_url(records),
+                    description: records |> List.first() |> Map.get(:assigns) |> Map.get(:bureaucrat_opts) |> Keyword.get(:detail, "/")
                   },
                   response:
                     Enum.map(records, fn record ->


### PR DESCRIPTION
I added `:detail` args as  postman description:

```elixir
 conn =
        post(conn, ~p"/api/v1/sites", site: @create_attrs)
        |> doc(detail: "test description")
```

![image](https://github.com/user-attachments/assets/62811f49-0ae1-4f3a-b66d-ec2aa6e3a000)
