### PR TITLE
Added support to JSON API request

### DIFF
--- a/lib/bureaucrat/postman_writer.ex
+++ b/lib/bureaucrat/postman_writer.ex
@@ -136,6 +136,17 @@ defmodule Bureaucrat.PostmanWriter do
     }
   end
 
+  defp build_req_body([first_record | _rest], "application/vnd.api+json") do
+    %{
+      mode: "raw",
+      raw: first_record.body_params |> strip__json_key() |> JSON.encode!(),
+      options: %{
+        raw: %{
+          language: "json"
+        }
+      }
+    }
+  end
   defp build_req_body(records, _) do
     %{
       mode: "formdata",


### PR DESCRIPTION
Added support to JSON API request in Postman, it create the right language type when the header is `application/vnd.api+json`